### PR TITLE
Multiple Gui Changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 - Experienced users with C# and ASP.NET Core may contribute pull requests to this project following the Coding Style below
 
 ## What we expect from users who want to contribute a pull request
-- Read the file [_Development/README.md](https://github.com/Legedric/ptmagic/blob/master/_Development/README.md) and follow the instructions carefully
+- Read the file [_Development/README.md](https://github.com/PTMagicians/PTMagic/blob/master/_Development/README.md) and follow the instructions carefully
 - In depth knowledge of the project PT Magic and what it is supposed to do
 - In depth knowledge of the architecture, the different parts and layers of PT Magic
 

--- a/Core/MarketAnalyzer/BaseAnalyzer.cs
+++ b/Core/MarketAnalyzer/BaseAnalyzer.cs
@@ -175,7 +175,7 @@ namespace Core.MarketAnalyzer
 
       try
       {
-        string baseUrl = "https://api.github.com/repos/legedric/ptmagic/releases/latest";
+        string baseUrl = "https://api.github.com/repos/PTMagicians/PTMagic/releases/latest";
 
         Newtonsoft.Json.Linq.JObject jsonObject = GetSimpleJsonObjectFromURL(baseUrl, log, true);
         if (jsonObject != null)

--- a/Core/ProfitTrailer/StrategyHelper.cs
+++ b/Core/ProfitTrailer/StrategyHelper.cs
@@ -87,7 +87,7 @@ namespace Core.ProfitTrailer
           result = "SOM";
           break;
         case "max buy times":
-          result = "MAX";
+          result = "DCAMAX";
           break;
         case "max pairs":
           result = "PAIRS";
@@ -121,6 +121,9 @@ namespace Core.ProfitTrailer
           break;
         case "rebuy timeout":
           result = "TIMEOUT";
+          break;
+        case "MIN/MAX CHANGE PERC":
+          result = "MIN/MAX";
           break;
         default:
           break;

--- a/Monitor/Pages/BagAnalyzer.cshtml
+++ b/Monitor/Pages/BagAnalyzer.cshtml
@@ -29,16 +29,15 @@
           <thead>
             <tr>
               <th data-fieldid="Market" data-tablesaw-sortable-col>Market</th>
+              <th data-fieldid="TotalCost" data-tablesaw-sortable-col data-sortable-numeric="true" class="text-right" data-toggle="tooltip" data-placement="top" title="Spent total cost in @Model.Summary.MainMarket">Value</th>
               <th data-fieldid="BoughtTimes" data-tablesaw-sortable-col data-sortable-numeric="true" class="text-right" data-toggle="tooltip" data-placement="top" title="Current DCA level">DCA</th>
               <th data-toggle="tooltip" data-placement="top" title="Active buy strategies">Buy Strats</th>
-              <th class="text-right" data-toggle="tooltip" data-placement="top" title="Current value relevant for buying the next DCA level">BT Value</th>
-              <th class="text-right" data-toggle="tooltip" data-placement="top" title="Next buy trigger as specified in your DCA properties">Buy Trigger</th>
+              <th class="text-right" data-toggle="tooltip" data-placement="top" title="Buy Strategy Value">BS Value</th>
+              <th class="text-right" data-toggle="tooltip" data-placement="top" title="Buy Strategy Trigger">BS Trigger</th>
               <th data-fieldid="ProfitPercent" data-tablesaw-sortable-col data-sortable-numeric="true" data-tablesaw-sortable-default-col class="text-right tablesaw-sortable-descending" data-toggle="tooltip" data-placement="top" title="Current profit percentage">Profit</th>
               <th data-toggle="tooltip" data-placement="top" title="Active sell strategies">Sell Strats</th>
-              <th class="text-right" data-toggle="tooltip" data-placement="top" title="Active sell trigger value">ST</th>
-              <th data-fieldid="CurrentPrice" data-tablesaw-sortable-col data-sortable-numeric="true" class="text-right" data-toggle="tooltip" data-placement="top" title="Current bid price for this market">Bid Price</th>
-              <th data-fieldid="AverageBuyPrice" data-tablesaw-sortable-col data-sortable-numeric="true" class="text-right" data-toggle="tooltip" data-placement="top" title="Average bought price for this market">Avg. Price</th>
-              <th data-fieldid="TotalCost" data-tablesaw-sortable-col data-sortable-numeric="true" class="text-right" data-toggle="tooltip" data-placement="top" title="Spent total cost in @Model.Summary.MainMarket">Cost</th>
+              <th class="text-right" data-toggle="tooltip" data-placement="top" title="Sell Strategy Trigger">SST</th>
+              <th class="text-right" data-toggle="tooltip" data-placement="top" title="Current Bid Order & Average Purchase Price">Bid Price<br>Avg Price</th>
               <th></th>
             </tr>
           </thead>

--- a/Monitor/Pages/DCACalculator.cshtml
+++ b/Monitor/Pages/DCACalculator.cshtml
@@ -23,7 +23,7 @@
       <p class="m-b-20">
         Use this calculator to help building a proper setup for your Profit Trailer settings for <b>ALL_max_trading_pairs</b>, <b>ALL_@maxCostCaption.ToLower()_cost</b> and <b>DCA levels</b>.<br />
         To do so enter your available balance and adjust the values to whatever you consider the best setting for your parameters.<br />
-        If you are having problems understanding the different modes, <a href="https://github.com/Legedric/ptmagic/wiki/DCA-Calculator" target="_blank">please read this wiki article</a>.
+        If you are having problems understanding the different modes, <a href="https://github.com/PTMagicians/PTMagic/wiki/DCA-Calculator" target="_blank">please read this wiki article</a>.
       </p>
 
       @if (Model.PTMagicConfiguration.GeneralSettings.Monitor.DefaultDCAMode.Equals("simple", StringComparison.InvariantCultureIgnoreCase)) {

--- a/Monitor/Pages/MarketAnalyzer.cshtml
+++ b/Monitor/Pages/MarketAnalyzer.cshtml
@@ -49,7 +49,7 @@
 
       @if (!Model.TrendChartDataJSON.Equals("")) {
         <div class="trend-chart">
-          <svg style="height:205px;width:100%"></svg>
+          <svg style="height:305px;width:100%"></svg>
         </div>
       } else {
         <p>Not able to load graph, no market trend data found.<br />If you still do not see a graph after more than hour, report an issue.</p>

--- a/Monitor/Pages/_Layout.cshtml
+++ b/Monitor/Pages/_Layout.cshtml
@@ -32,7 +32,7 @@
           <span class="logo-version">
             v<span>@Model.CurrentBotVersion</span>
             @if (!Core.Helper.SystemHelper.IsRecentVersion(Model.CurrentBotVersion, Model.LatestVersion)) {
-              <a href="https://github.com/Legedric/ptmagic/releases" target="_blank"><i class="fa fa-exclamation-triangle text-warning" data-toggle="tooltip" data-placement="top" title="Your PT Magic is out of date. Click here to get to the latest release."></i></a>
+              <a href="https://github.com/PTMagicians/PTMagic/releases" target="_blank"><i class="fa fa-exclamation-triangle text-warning" data-toggle="tooltip" data-placement="top" title="Your PT Magic is out of date. Click here to get to the latest release."></i></a>
             } else {
               <i class="fa fa-check text-success" data-toggle="tooltip" data-placement="top" title="Your PT Magic is up to date."></i>
             }
@@ -113,7 +113,7 @@
             }
 
             <li>
-              <a href="https://github.com/Legedric/ptmagic/wiki" target="_blank"><i class="fa fa-book fa-2x"></i> <span> Wiki </span></a>
+              <a href="https://github.com/PTMagicians/PTMagic/wiki" target="_blank"><i class="fa fa-book fa-2x"></i> <span> Wiki </span></a>
             </li>
 
             <li>
@@ -140,11 +140,9 @@
     <div class="container">
       <div class="row">
         <div class="col-12 text-center">
-          <a href="http://www.profit-trailer-magic.com/" target="_blank">www.profit-trailer-magic.com</a>
+          <a href="https://github.com/PTMagicians/PTMagic" target="_blank">GitHub</a>
           |
-          <a href="https://github.com/Legedric/ptmagic" target="_blank">GitHub</a>
-          |
-          <a href="https://github.com/Legedric/ptmagic/wiki" target="_blank">Wiki</a>
+          <a href="https://github.com/PTMagicians/PTMagic/wiki" target="_blank">Wiki</a>
         </div>
       </div>
     </div>

--- a/Monitor/Pages/_get/BagList.cshtml
+++ b/Monitor/Pages/_get/BagList.cshtml
@@ -81,6 +81,7 @@
     } else {
       <th class="align-top"><a href="@Core.Helper.SystemHelper.GetMarketLink(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform,Model.PTMagicConfiguration.GeneralSettings.Application.Exchange, dcaLogEntry.Market, Model.Summary.MainMarket)" target="_blank">@dcaLogEntry.Market</a> <i class="fa fa-exclamation-triangle text-highlight" data-toggle="tooltip" data-placement="top" data-html="true" title="@await Component.InvokeAsync("PairIcon", mps)" data-template="<div class='tooltip' role='tooltip'><div class='tooltip-arrow'></div><div class='tooltip-inner pair-tooltip'></div></div>"></i></th>
     }
+    <td class="text-right">@Html.Raw(@dcaLogEntry.TotalCost.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US")) + "(" + Model.MainFiatCurrencySymbol + currentFiatValue.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + ")")</td>
     <td class="text-right">
       @if (dcaLogEntry.BoughtTimes > 0) {
         @dcaLogEntry.BoughtTimes;
@@ -110,9 +111,8 @@
     <td class="text-right text-nowrap">
       @Html.Raw(triggerSellValueText)
     </td>
-    <td class="text-right">@dcaLogEntry.CurrentPrice.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US"))</td>
-    <td class="text-right">@dcaLogEntry.AverageBuyPrice.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US"))</td>
-    <td class="text-right">@Html.Raw(@dcaLogEntry.TotalCost.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US")) + "  (" + Model.MainFiatCurrencySymbol + currentFiatValue.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + ")")</td>
+    <td class="text-right">@dcaLogEntry.CurrentPrice.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US"))<br>@dcaLogEntry.AverageBuyPrice.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US"))</td>
+    
     <td><a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)_get/BagDetails/?m=@dcaLogEntry.Market" data-remote="false" data-toggle="modal" data-target="#dca-chart" class="btn btn-sm btn-ptmagic">Details</a></td>
   </tr>
 }

--- a/Monitor/Pages/_get/DashboardBottom.cshtml
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml
@@ -7,6 +7,45 @@
 <div class="row">
   <div class="col-md-6">
     <div class="card-box">
+      <h4 class="m-t-0 m-b-20 header-title"><b>Market Trends</b><small class="pull-right"><a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)MarketAnalyzer">more</a></small></h4>
+
+      <table class="table table-sm">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th class="text-right">Markets</th>
+            <th class="text-right">Timeframe</th>
+            <th class="text-right">Change</th>
+          </tr>
+        </thead>
+        <tbody>
+          @foreach (var marketTrend in Model.MarketTrends.OrderBy(mt => mt.TrendMinutes)) {
+            if (Model.Summary.MarketTrendChanges.ContainsKey(marketTrend.Name)) {
+              double trendChange = Model.Summary.MarketTrendChanges[marketTrend.Name].OrderByDescending(mtc => mtc.TrendDateTime).First().TrendChange;
+              string trendChangeOutput = trendChange.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"));
+
+              int marketCount = marketTrend.MaxMarkets;
+              string marketCountString = marketCount.ToString();
+
+              if (marketCount == 0) {
+                marketCountString = "All";
+              } else if (marketCount > Model.Summary.MarketSummary.Keys.Count && marketTrend.Platform.Equals("Exchange", StringComparison.InvariantCultureIgnoreCase)) {
+                marketCountString = Model.Summary.MarketSummary.Keys.Count.ToString();
+              }
+              <tr>
+                <td>@Core.Helper.SystemHelper.SplitCamelCase(marketTrend.Name)</td>
+                <td class="text-right">@marketCountString</td>
+                <td class="text-right">@Core.Helper.SystemHelper.GetProperDurationTime(marketTrend.TrendMinutes * 60, false)</td>
+                <td class="text-right text-autocolor">@trendChangeOutput%</td>
+              </tr>
+            }
+          }
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card-box">
       <h4 class="m-t-0 m-b-20 header-title"><b>Sales Overview</b><small class="pull-right"><a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)SalesAnalyzer">more</a></small></h4>
       @{
         double totalProfit = Model.PTData.SellLog.Sum(s => s.Profit);
@@ -76,72 +115,33 @@
       </table>
     </div>
   </div>
-  <div class="col-md-6">
-    <div class="card-box">
-      <h4 class="m-t-0 m-b-20 header-title"><b>Market Trends</b><small class="pull-right"><a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)MarketAnalyzer">more</a></small></h4>
-
-      <table class="table table-sm">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th class="text-right">Markets</th>
-            <th class="text-right">Timeframe</th>
-            <th class="text-right">Change</th>
-          </tr>
-        </thead>
-        <tbody>
-          @foreach (var marketTrend in Model.MarketTrends.OrderBy(mt => mt.TrendMinutes)) {
-            if (Model.Summary.MarketTrendChanges.ContainsKey(marketTrend.Name)) {
-              double trendChange = Model.Summary.MarketTrendChanges[marketTrend.Name].OrderByDescending(mtc => mtc.TrendDateTime).First().TrendChange;
-              string trendChangeOutput = trendChange.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"));
-
-              int marketCount = marketTrend.MaxMarkets;
-              string marketCountString = marketCount.ToString();
-
-              if (marketCount == 0) {
-                marketCountString = "All";
-              } else if (marketCount > Model.Summary.MarketSummary.Keys.Count && marketTrend.Platform.Equals("Exchange", StringComparison.InvariantCultureIgnoreCase)) {
-                marketCountString = Model.Summary.MarketSummary.Keys.Count.ToString();
-              }
-              <tr>
-                <td>@Core.Helper.SystemHelper.SplitCamelCase(marketTrend.Name)</td>
-                <td class="text-right">@marketCountString</td>
-                <td class="text-right">@Core.Helper.SystemHelper.GetProperDurationTime(marketTrend.TrendMinutes * 60, false)</td>
-                <td class="text-right text-autocolor">@trendChangeOutput%</td>
-              </tr>
-            }
-          }
-        </tbody>
-      </table>
-    </div>
-  </div>
 
 </div>
 
 <div class="row">
-  <div class="col-md-6">
-    <div class="card-box" style="height:205px;">
-      @if (!Model.ProfitChartDataJSON.Equals("")) {
-        <div class="profit-chart">
-          <svg style="height:205px;width:100%"></svg>
-        </div>
-      } else {
-        <p>Not able to load graph, no sales data found.<br />If you still do not see a graph after you made your first sale, report an issue.</p>
-      }
-    </div>
-  </div>
-
-  <div class="col-md-6">
-    <div class="card-box" style="height:205px;">
+   <div class="col-md-6">
+    <div class="card-box" style="height:305px;">
       @if (!Model.TrendChartDataJSON.Equals("")) {
         <div class="trend-chart">
-          <svg style="height:205px;width:100%"></svg>
+          <svg style="height:305px;width:100%"></svg>
         </div>
       } else {
         <p>Not able to load graph, no market trend data found.<br />If you still do not see a graph after more than hour, report an issue.</p>
       }
     </div>
   </div>
+  <div class="col-md-6">
+    <div class="card-box" style="height:305px;">
+      @if (!Model.ProfitChartDataJSON.Equals("")) {
+        <div class="profit-chart">
+          <svg style="height:305px;width:100%"></svg>
+        </div>
+      } else {
+        <p>Not able to load graph, no sales data found.<br />If you still do not see a graph after you made your first sale, report an issue.</p>
+      }
+    </div>
+  </div>
+ 
 </div>
 
 <script type="text/javascript">

--- a/Monitor/Pages/_get/DashboardTop.cshtml
+++ b/Monitor/Pages/_get/DashboardTop.cshtml
@@ -82,12 +82,12 @@
           <thead>
             <tr>
               <th>Market</th>
+              <th class="text-left" data-toggle="tooltip" data-placement="top" title="Current Total Value">Value</th>
               <th class="text-right" data-toggle="tooltip" data-placement="top" title="Current DCA level">DCA</th>
               <th data-toggle="tooltip" data-placement="top" title="Active buy strategies">Buy Strats</th>
               <th data-toggle="tooltip" data-placement="top" title="Active sell strategies">Sell Strats</th>
               <th class="text-right" data-toggle="tooltip" data-placement="top" title=""></th>
               <th class="text-left" data-toggle="tooltip" data-placement="top" title="Current Profit">Profit</th>
-              <th class="text-left" data-toggle="tooltip" data-placement="top" title="Current Total Cost">Cost</th>
               <th></th>
             </tr>
           </thead>
@@ -139,6 +139,8 @@
                 } else {
                   <th class="align-top"><a href="@Core.Helper.SystemHelper.GetMarketLink(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform,Model.PTMagicConfiguration.GeneralSettings.Application.Exchange, dcaLogEntry.Market, Model.Summary.MainMarket)" target="_blank">@dcaLogEntry.Market</a> <i class="fa fa-exclamation-triangle text-highlight" data-toggle="tooltip" data-placement="top" data-html="true" title="@await Component.InvokeAsync("PairIcon", mps)" data-template="<div class='tooltip' role='tooltip'><div class='tooltip-arrow'></div><div class='tooltip-inner pair-tooltip'></div></div>"></i></th>
                 }
+                
+                <td class="text-left">@Html.Raw(dcaLogEntry.TotalCost.ToString("#,#0.000000", new System.Globalization.CultureInfo("en-US")))</td> 
                 <td class="text-right">
                   @if (dcaEnabled) {
                     @if (dcaLogEntry.BoughtTimes > 0) {
@@ -161,7 +163,6 @@
                  
                 </td>
                 <td class="text-autocolor">@dcaLogEntry.ProfitPercent.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"))%</td>
-                <td class="text-left">@Html.Raw(dcaLogEntry.TotalCost.ToString("#,#0.000000", new System.Globalization.CultureInfo("en-US")) + " (" + Model.MainFiatCurrencySymbol + @currentFiatValue.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + ")")</td> 
                 <td class="text-right"><a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)_get/BagDetails/?m=@dcaLogEntry.Market" data-remote="false" data-toggle="modal" data-target="#dca-chart" class="btn btn-mini btn-ptmagic"><i class="fa fa-plus"></i></a></td>
               </tr>
             }

--- a/Monitor/wwwroot/assets/js/analyzer-settings.js
+++ b/Monitor/wwwroot/assets/js/analyzer-settings.js
@@ -16,11 +16,11 @@ const GSStandardTriggerTemplate = ({ settingType, settingName, trendName, market
     </div>
     <div class="col-md-3">
       <input type="text" class="form-control" placeholder="MinChange in %" name="MarketAnalyzer_${settingType}_${settingName}|Trigger_${trendName}|MinChange" value="${minChange}">
-      <span class="help-block"><small>Min. trend change % - <a href="https://github.com/Legedric/ptmagic/wiki/MinChange-&-MaxChange" target="_blank">Read the Wiki!</a></small></span>
+      <span class="help-block"><small>Min. trend change % - <a href="https://github.com/PTMagicians/PTMagic/wiki/MinChange-&-MaxChange" target="_blank">Read the Wiki!</a></small></span>
     </div>
     <div class="col-md-3">
       <input type="text" class="form-control" placeholder="MaxChange in %" name="MarketAnalyzer_${settingType}_${settingName}|Trigger_${trendName}|MaxChange" value="${maxChange}">
-      <span class="help-block"><small>Max. trend change % - <a href="https://github.com/Legedric/ptmagic/wiki/MinChange-&-MaxChange" target="_blank">Read the Wiki!</a></small></span>
+      <span class="help-block"><small>Max. trend change % - <a href="https://github.com/PTMagicians/PTMagic/wiki/MinChange-&-MaxChange" target="_blank">Read the Wiki!</a></small></span>
     </div>
     <div class="col-md-2"><button class="btn btn-danger btn-custom btn-block text-uppercase waves-effect waves-light btn-remove-parentrow-${settingType}-${settingName}">Remove</button></div>
   </div>
@@ -42,11 +42,11 @@ const SMSStandardTriggerTemplate = ({ settingType, settingName, trendName, trigg
     </div>
     <div class="col-md-2">
       <input type="text" class="form-control" placeholder="MinChange in %" name="MarketAnalyzer_${settingType}_${settingName}|${triggerPrefix}Trigger_${trendName}|MinChange" value="${minChange}">
-      <span class="help-block"><small>Min. trend change % - <a href="https://github.com/Legedric/ptmagic/wiki/MinChange-&-MaxChange" target="_blank">Read the Wiki!</a></small></span>
+      <span class="help-block"><small>Min. trend change % - <a href="https://github.com/PTMagicians/PTMagic/wiki/MinChange-&-MaxChange" target="_blank">Read the Wiki!</a></small></span>
     </div>
     <div class="col-md-2">
       <input type="text" class="form-control" placeholder="MaxChange in %" name="MarketAnalyzer_${settingType}_${settingName}|${triggerPrefix}Trigger_${trendName}|MaxChange" value="${maxChange}">
-      <span class="help-block"><small>Max. trend change % - <a href="https://github.com/Legedric/ptmagic/wiki/MinChange-&-MaxChange" target="_blank">Read the Wiki!</a></small></span>
+      <span class="help-block"><small>Max. trend change % - <a href="https://github.com/PTMagicians/PTMagic/wiki/MinChange-&-MaxChange" target="_blank">Read the Wiki!</a></small></span>
     </div>
     <div class="col-md-2"><button class="btn btn-danger btn-custom btn-block text-uppercase waves-effect waves-light btn-remove-parentrow-${settingType}-${settingName}">Remove</button></div>
   </div>
@@ -103,7 +103,7 @@ const PropertyTemplate = ({ settingType, settingName, propertyType, propertyKey,
       <select name="MarketAnalyzer_${settingType}_${settingName}|${propertyType}Property_${propertyKeySimple}|ValueMode" class="form-control">
         ${valueModes}
       </select>
-      <span class="help-block"><small>Value mode - <a href="https://github.com/Legedric/ptmagic/wiki/Writing-Properties" target="_blank">Read the Wiki!</a></small></span>
+      <span class="help-block"><small>Value mode - <a href="https://github.com/PTMagicians/PTMagic/wiki/Writing-Properties" target="_blank">Read the Wiki!</a></small></span>
     </div>
     <div class="col-md-2"><button class="btn btn-danger btn-custom btn-block text-uppercase waves-effect waves-light btn-remove-parentrow-${settingType}-${settingName}">Remove</button></div>
   </div>


### PR DESCRIPTION
Changed all links to the new repository

Strategy helper: Added "MIN/MAX" for "Min/Max change pct" 
Strategy helper: changed "Max" to "DCAMAX" (avoid confusing with min/max)  
Strategy helper: Shortened "rebuy timeout"   to "TIMEOUT" 

Dashboard  -- Moved "value" to the left - removed dollar amount
Dashboard bottom - swapped sales & Market panels, so the entire page shows market data on the left, personal data on the right
Made Trend and Sales line charts a bit taller for better readability

Bag Analyzer heading -- changed "BT Value" to match PT:  "BSV - Buy Strategy Value"
Bag Analyzer heading  -- changed  "Buy Trigger"  to match PT:  "BST - Buy Strategy Target"
Bag Analyzer heading -- changed  "ST"  to match PT:   "SST - Sell Strategy Target"
Bag Analyzer heading  -- changed "Cost"  to "Value" and moved to left to match Dashboard
Bag Analyzer heading -- Stacked bid and avg price for easier comparison