### PR TITLE
PT 2.2 Unfinished Changes

### DIFF
--- a/Core/DataObjects/PTMagicData.cs
+++ b/Core/DataObjects/PTMagicData.cs
@@ -35,9 +35,9 @@ namespace Core.Main.DataObjects.PTMagicData
     public bool IsEnabled { get; set; } = true;
     public bool TestMode { get; set; } = true;
     public bool EnableBetaFeatures { get; set; } = false;
-    public int ProfitTrailerMajorVersion { get; set; } = 1;
     public string ProfitTrailerPath { get; set; }
     public string ProfitTrailerLicense { get; set; } = "";
+    public string ProfitTrailerServerAPIToken { get; set; }
     public string ProfitTrailerMonitorURL { get; set; } = "http://localhost:8081/";
     public string ProfitTrailerDefaultSettingName { get; set; } = "default";
     public bool AlwaysLoadDefaultBeforeSwitch { get; set; } = true;
@@ -316,7 +316,6 @@ namespace Core.Main.DataObjects.PTMagicData
     public double MainMarketPrice { get; set; } = 0;
     public string MainFiatCurrency { get; set; } = "USD";
     public double MainFiatCurrencyExchangeRate { get; set; } = 1;
-    public int ProfitTrailerMajorVersion { get; set; } = 1;
     public List<StrategySummary> BuyStrategies { get; set; } = new List<StrategySummary>();
     public List<StrategySummary> SellStrategies { get; set; } = new List<StrategySummary>();
     public List<StrategySummary> DCABuyStrategies { get; set; } = new List<StrategySummary>();
@@ -408,12 +407,13 @@ namespace Core.Main.DataObjects.PTMagicData
   public class sellLogData
   {
     public double soldAmount { get; set; }
-    public SoldDate soldDate { get; set; }
+    public double soldDate { get; set; }
     public int boughtTimes { get; set; }
     public string market { get; set; }
     public double profit { get; set; }
     public AverageCalculator averageCalculator { get; set; }
     public double currentPrice { get; set; }
+    public double fee { get; set; }
   }
 
   public class SellLogData
@@ -430,33 +430,6 @@ namespace Core.Main.DataObjects.PTMagicData
     public double SoldValue { get; set; }
   }
 
-  public class SoldDate
-  {
-    public Date date { get; set; }
-    public Time time { get; set; }
-  }
-
-  public class FirstBoughtDate
-  {
-    public Date date { get; set; }
-    public Time time { get; set; }
-  }
-
-  public class Date
-  {
-    public int year { get; set; }
-    public int month { get; set; }
-    public int day { get; set; }
-  }
-
-  public class Time
-  {
-    public int hour { get; set; }
-    public int minute { get; set; }
-    public int second { get; set; }
-    public int nano { get; set; }
-  }
-
   public class AverageCalculator
   {
     public double totalCost { get; set; }
@@ -464,10 +437,7 @@ namespace Core.Main.DataObjects.PTMagicData
     public double totalAmountWithSold { get; set; }
     public double avgPrice { get; set; }
     public double avgCost { get; set; }
-    public FirstBoughtDate firstBoughtDate { get; set; }
     public double totalWeightedPrice { get; set; }
-    public double orderNumber { get; set; }
-    public double fee { get; set; }
   }
 
   public class PTStrategy
@@ -494,6 +464,7 @@ namespace Core.Main.DataObjects.PTMagicData
     public double highbb { get; set; }
     public double profit { get; set; }
     public AverageCalculator averageCalculator { get; set; }
+    public int firstBoughtDate { get; set; }
     public double currentPrice { get; set; }
     public string sellStrategy { get; set; }
     public string buyStrategy { get; set; }

--- a/Core/DataObjects/ProfitTrailerData.cs
+++ b/Core/DataObjects/ProfitTrailerData.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
@@ -20,27 +22,31 @@ namespace Core.Main.DataObjects
     private PTMagicConfiguration _systemConfiguration = null;
     private TransactionData _transactionData = null;
     private DateTimeOffset _dateTimeNow = Constants.confMinDate;
-
-    public ProfitTrailerData(string ptmBasePath, PTMagicConfiguration systemConfiguration)
+    
+    public ProfitTrailerData(PTMagicConfiguration systemConfiguration)
     {
-      _ptmBasePath = ptmBasePath;
-      _systemConfiguration = systemConfiguration;
+      string html = "";
+      string url = systemConfiguration.GeneralSettings.Application.ProfitTrailerMonitorURL + "api/data?token=" + systemConfiguration.GeneralSettings.Application.ProfitTrailerServerAPIToken;
 
-      // Find the path to the Profit Trailer data file
-      string ptDataFilePath = Path.Combine(systemConfiguration.GeneralSettings.Application.ProfitTrailerPath, "data", "ProfitTrailerData.json");
-
-      if (!File.Exists(ptDataFilePath))
+      try
       {
-        // Try the older location for PT 1.x and PT 2.0.x
-        ptDataFilePath = Path.Combine(systemConfiguration.GeneralSettings.Application.ProfitTrailerPath, "ProfitTrailerData.json");
-        if (!File.Exists(ptDataFilePath))
-        {
-          // Can't find the Profit Trailer Data
-          throw new Exception("Unable to load Profit Trailer data file at: " + ptDataFilePath);
-        }
+        HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
+        request.AutomaticDecompression = DecompressionMethods.GZip;
+
+        WebResponse response = request.GetResponse();
+        Stream dataStream = response.GetResponseStream();
+        StreamReader reader = new StreamReader(dataStream);
+        html = reader.ReadToEnd();
+        reader.Close();
+        response.Close();
+
+      }
+      catch (System.Exception)
+      {
+          throw;
       }
 
-      PTData rawPTData = JsonConvert.DeserializeObject<PTData>(File.ReadAllText(ptDataFilePath));
+      PTData rawPTData = JsonConvert.DeserializeObject<PTData>(html);
       if (rawPTData.SellLogData != null)
       {
         this.BuildSellLogData(rawPTData.SellLogData, _systemConfiguration);
@@ -147,12 +153,16 @@ namespace Core.Main.DataObjects
         sellLogData.TotalCost = sellLogData.SoldAmount * sellLogData.AverageBuyPrice;
 
         double soldValueRaw = (sellLogData.SoldAmount * sellLogData.SoldPrice);
-        double soldValueAfterFees = soldValueRaw - (soldValueRaw * (rsld.averageCalculator.fee / 100));
+        double soldValueAfterFees = soldValueRaw - (soldValueRaw * (rsld.fee / 100));
         sellLogData.SoldValue = soldValueAfterFees;
-        sellLogData.Profit = Math.Round(sellLogData.SoldValue - sellLogData.TotalCost, 8);
+        sellLogData.Profit = Math.Round(sellLogData.SoldValue - sellLogData.TotalCost, 8);    
+
+        //Convert Unix Timestamp to Datetime
+        System.DateTime dtDateTime = new DateTime(1970,1,1,0,0,0,System.DateTimeKind.Utc);
+        dtDateTime = dtDateTime.AddSeconds(rsld.soldDate).ToLocalTime();  
 
         // Profit Trailer sales are saved in UTC
-        DateTimeOffset ptSoldDate = DateTimeOffset.Parse(rsld.soldDate.date.year.ToString() + "-" + rsld.soldDate.date.month.ToString("00") + "-" + rsld.soldDate.date.day.ToString("00") + "T" + rsld.soldDate.time.hour.ToString("00") + ":" + rsld.soldDate.time.minute.ToString("00") + ":" + rsld.soldDate.time.second.ToString("00"), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+        DateTimeOffset ptSoldDate = DateTimeOffset.Parse(dtDateTime.Year.ToString() + "-" + dtDateTime.Month.ToString("00") + "-" + dtDateTime.Day.ToString("00") + "T" + dtDateTime.Hour.ToString("00") + ":" + dtDateTime.Minute.ToString("00") + ":" + dtDateTime.Second.ToString("00"), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
 
         // Convert UTC sales time to local offset time
         TimeSpan offsetTimeSpan = TimeSpan.Parse(systemConfiguration.GeneralSettings.Application.TimezoneOffset.Replace("+", ""));
@@ -235,11 +245,14 @@ namespace Core.Main.DataObjects
           }
         }
 
+        //Convert Unix Timestamp to Datetime
+        System.DateTime rdldDateTime = new DateTime(1970,1,1,0,0,0,System.DateTimeKind.Utc);
+        rdldDateTime = rdldDateTime.AddSeconds(rdld.firstBoughtDate).ToLocalTime();
 
         // Profit Trailer bought times are saved in UTC
-        if (rdld.averageCalculator.firstBoughtDate != null)
+        if (rdld.firstBoughtDate != null)
         {
-          DateTimeOffset ptFirstBoughtDate = DateTimeOffset.Parse(rdld.averageCalculator.firstBoughtDate.date.year.ToString() + "-" + rdld.averageCalculator.firstBoughtDate.date.month.ToString("00") + "-" + rdld.averageCalculator.firstBoughtDate.date.day.ToString("00") + "T" + rdld.averageCalculator.firstBoughtDate.time.hour.ToString("00") + ":" + rdld.averageCalculator.firstBoughtDate.time.minute.ToString("00") + ":" + rdld.averageCalculator.firstBoughtDate.time.second.ToString("00"), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+          DateTimeOffset ptFirstBoughtDate = DateTimeOffset.Parse(rdldDateTime.Year.ToString() + "-" + rdldDateTime.Month.ToString("00") + "-" + rdldDateTime.Day.ToString("00") + "T" + rdldDateTime.Hour.ToString("00") + ":" + rdldDateTime.Minute.ToString("00") + ":" + rdldDateTime.Second.ToString("00"), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
 
           // Convert UTC bought time to local offset time
           TimeSpan offsetTimeSpan = TimeSpan.Parse(systemConfiguration.GeneralSettings.Application.TimezoneOffset.Replace("+", ""));
@@ -294,10 +307,14 @@ namespace Core.Main.DataObjects
           }
         }
 
+        //Convert Unix Timestamp to Datetime
+        System.DateTime rpldDateTime = new DateTime(1970,1,1,0,0,0,System.DateTimeKind.Utc);
+        rpldDateTime = rpldDateTime.AddSeconds(rpld.firstBoughtDate).ToLocalTime();
+
         // Profit Trailer bought times are saved in UTC
-        if (rpld.averageCalculator.firstBoughtDate != null)
+        if (rpld.firstBoughtDate != null)
         {
-          DateTimeOffset ptFirstBoughtDate = DateTimeOffset.Parse(rpld.averageCalculator.firstBoughtDate.date.year.ToString() + "-" + rpld.averageCalculator.firstBoughtDate.date.month.ToString("00") + "-" + rpld.averageCalculator.firstBoughtDate.date.day.ToString("00") + "T" + rpld.averageCalculator.firstBoughtDate.time.hour.ToString("00") + ":" + rpld.averageCalculator.firstBoughtDate.time.minute.ToString("00") + ":" + rpld.averageCalculator.firstBoughtDate.time.second.ToString("00"), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+          DateTimeOffset ptFirstBoughtDate = DateTimeOffset.Parse(rpldDateTime.Year.ToString() + "-" + rpldDateTime.Month.ToString("00") + "-" + rpldDateTime.Day.ToString("00") + "T" + rpldDateTime.Hour.ToString("00") + ":" + rpldDateTime.Minute.ToString("00") + ":" + rpldDateTime.Second.ToString("00"), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
 
           // Convert UTC bought time to local offset time
           TimeSpan offsetTimeSpan = TimeSpan.Parse(systemConfiguration.GeneralSettings.Application.TimezoneOffset.Replace("+", ""));

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -31,7 +31,6 @@ namespace Core.Main
     private int _state = 0;
     private int _runCount = 0;
     private int _totalElapsedSeconds = 0;
-    private int _profitTrailerMajorVersion = 0;
     private int _configCheckRetryCount = 0;
     private bool _configCheckResult = true;
     private bool _globalSettingWritten = false;
@@ -146,18 +145,6 @@ namespace Core.Main
       set
       {
         _totalElapsedSeconds = value;
-      }
-    }
-
-    public int ProfitTrailerMajorVersion
-    {
-      get
-      {
-        return _profitTrailerMajorVersion;
-      }
-      set
-      {
-        _profitTrailerMajorVersion = value;
       }
     }
 
@@ -622,6 +609,9 @@ namespace Core.Main
     {
       bool result = true;
 
+      //Import Initial ProfitTrailer Information
+      SettingsAPI.GetInitialProfitTrailerSettings(this.PTMagicConfiguration);
+
       // Check for valid default setting
       GlobalSetting defaultSetting = this.PTMagicConfiguration.AnalyzerSettings.GlobalSettings.Find(s => s.SettingName.Equals("default", StringComparison.InvariantCultureIgnoreCase));
       if (defaultSetting == null)
@@ -662,17 +652,7 @@ namespace Core.Main
         if (ptRoot.Exists)
         {
           this.Log.DoLogInfo("Profit Trailer directory found");
-
-          // Run checks dependant on PT version
-          this.ProfitTrailerMajorVersion = this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerMajorVersion;
-          if (this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerMajorVersion < 2)
-          {
-            result = RunProfitTrailerTradingFilesChecks();
-          }
-          else
-          {
-            result = RunProfitTrailerSettingsAPIChecks();
-          }
+          result = RunProfitTrailerSettingsAPIChecks();
         }
         else
         {
@@ -700,153 +680,74 @@ namespace Core.Main
       return result;
     }
 
-    private bool RunProfitTrailerTradingFilesChecks()
-    {
-      bool result = true;
-
-      this.Log.DoLogInfo("========== STARTING CHECKS FOR Profit Trailer 1.x ==========");
-
-      // Check for settings directory "trading"
-      string ptTradingPath = this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar;
-      DirectoryInfo ptTrading = new DirectoryInfo(ptTradingPath);
-      if (ptTrading.Exists)
-      {
-        this.Log.DoLogInfo("Profit Trailer 1.x check: Trading directory found");
-
-        #region File Checks
-        this.Log.DoLogInfo("Profit Trailer 1.x check: Checking for Pairs Properties file");
-        if (File.Exists(this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + this.PairsFileName))
-        {
-          this.Log.DoLogInfo("Profit Trailer 1.x check: PAIRS.PROPERTIES found!");
-        }
-        else
-        {
-          this.PairsFileName = "PAIRS.properties";
-          if (File.Exists(this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + this.PairsFileName))
-          {
-            this.Log.DoLogInfo("Profit Trailer 1.x check: PAIRS.properties found!");
-          }
-          else
-          {
-            this.Log.DoLogError("Profit Trailer 1.x check: No 'PAIRS.properties' found in " + this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar);
-            result = false;
-          }
-        }
-
-        this.Log.DoLogInfo("Profit Trailer 1.x check: Checking for DCA Properties file");
-        if (File.Exists(this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + this.DCAFileName))
-        {
-          this.Log.DoLogInfo("Profit Trailer 1.x check: DCA.PROPERTIES found!");
-        }
-        else
-        {
-          this.DCAFileName = "DCA.properties";
-          if (File.Exists(this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + this.DCAFileName))
-          {
-            this.Log.DoLogInfo("Profit Trailer 1.x check: DCA.properties found!");
-          }
-          else
-          {
-            this.Log.DoLogError("Profit Trailer 1.x check: No 'DCA.properties' found in " + this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar);
-            result = false;
-          }
-        }
-
-        this.Log.DoLogInfo("Profit Trailer 1.x check: Checking for Indicators Properties file");
-        if (File.Exists(this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + this.IndicatorsFileName))
-        {
-          this.Log.DoLogInfo("Profit Trailer 1.x check: INDICATORS.PROPERTIES found!");
-        }
-        else
-        {
-          this.IndicatorsFileName = "INDICATORS.properties";
-          if (File.Exists(this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + this.IndicatorsFileName))
-          {
-            this.Log.DoLogInfo("Profit Trailer 1.x check: INDICATORS.properties found!");
-          }
-          else
-          {
-            this.Log.DoLogError("Profit Trailer 1.x check: No 'INDICATORS.properties' found in " + this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar);
-            result = false;
-          }
-        }
-        #endregion
-      }
-      else
-      {
-        this.Log.DoLogError("Profit Trailer 1.x check: Trading settings directory not found (" + ptTradingPath + ")");
-        result = false;
-      }
-
-      if (result)
-      {
-        this.Log.DoLogInfo("========== CHECKS FOR Profit Trailer 1.x COMPLETED! ==========");
-      }
-      else
-      {
-        this.Log.DoLogInfo("========== CHECKS FOR Profit Trailer 1.x FAILED! ==========");
-      }
-
-      return result;
-    }
-
     private bool RunProfitTrailerSettingsAPIChecks()
     {
       bool result = true;
 
-      this.Log.DoLogInfo("========== STARTING CHECKS FOR Profit Trailer 2.x ==========");
+      this.Log.DoLogInfo("========== STARTING CHECKS FOR Profit Trailer ==========");
 
       // Check for PT license key
       if (!this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerLicense.Equals(""))
       {
-        this.Log.DoLogInfo("Profit Trailer 2.x check: Profit Trailer license found");
+        this.Log.DoLogInfo("Profit Trailer check: Profit Trailer license found");
       }
       else
       {
-        this.Log.DoLogError("Profit Trailer 2.x check: No Profit Trailer license key specified! The license key is necessary to adjust your Profit Trailer settings since 2.0");
+        this.Log.DoLogError("Profit Trailer check: No Profit Trailer license key specified! The license key is necessary to adjust your Profit Trailer settings");
+        result = false;
+      }
+
+      //Check for ptServerAPIToken
+      if (!this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerServerAPIToken.Equals(""))
+      {
+        this.Log.DoLogInfo("Profit Trailer check: Profit Trailer Server API Token Specified");
+      }
+      else
+      {
+        this.Log.DoLogError("Profit Trailer check: No Server API Token specified. It has to be the same Token as in the Profit Trailer Config File");
         result = false;
       }
 
       // Check for PT default setting key
       if (!this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerDefaultSettingName.Equals(""))
       {
-        this.Log.DoLogInfo("Profit Trailer 2.x check: Profit Trailer default setting name specified");
+        this.Log.DoLogInfo("Profit Trailer check: Profit Trailer default setting name specified");
       }
       else
       {
-        this.Log.DoLogError("Profit Trailer 2.x check: No Profit Trailer default setting name specified! The default setting name is necessary to adjust your Profit Trailer settings since 2.0");
+        this.Log.DoLogError("Profit Trailer check: No Profit Trailer default setting name specified! The default setting name is necessary to adjust your Profit Trailer settings since 2.0");
         result = false;
       }
 
       // Check for PT monitor
       if (!this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerMonitorURL.Equals(""))
       {
-        this.Log.DoLogInfo("Profit Trailer 2.x check: Profit Trailer monitor URL found");
+        this.Log.DoLogInfo("Profit Trailer check: Profit Trailer monitor URL found");
       }
       else
       {
-        this.Log.DoLogError("Profit Trailer 2.x check: No Profit Trailer monitor URL specified! The monitor URL is necessary to adjust your Profit Trailer settings since 2.0");
+        this.Log.DoLogError("Profit Trailer check: No Profit Trailer monitor URL specified! The monitor URL is necessary to adjust your Profit Trailer settings since 2.0");
         result = false;
       }
 
       // Check if PT monitor is reachable
       if (SystemHelper.UrlIsReachable(this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerMonitorURL))
       {
-        this.Log.DoLogInfo("Profit Trailer 2.x check: Profit Trailer monitor connection test succeeded");
+        this.Log.DoLogInfo("Profit Trailer check: Profit Trailer monitor connection test succeeded");
       }
       else
       {
-        this.Log.DoLogError("Profit Trailer 2.x check: Your Profit Trailer monitor (" + this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerMonitorURL + ") is not available! Make sure your Profit Trailer bot is up and running and your monitor is accessible.");
+        this.Log.DoLogError("Profit Trailer check: Your Profit Trailer monitor (" + this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerMonitorURL + ") is not available! Make sure your Profit Trailer bot is up and running and your monitor is accessible.");
         result = false;
       }
 
       if (result)
       {
-        this.Log.DoLogInfo("========== CHECKS FOR Profit Trailer 2.x COMPLETED! ==========");
+        this.Log.DoLogInfo("========== CHECKS FOR Profit Trailer COMPLETED! ==========");
       }
       else
       {
-        this.Log.DoLogInfo("========== CHECKS FOR Profit Trailer 2.x FAILED! ==========");
+        this.Log.DoLogInfo("========== CHECKS FOR Profit Trailer FAILED! ==========");
       }
 
       return result;
@@ -1137,24 +1038,12 @@ namespace Core.Main
 
     private void LoadCurrentProfitTrailerProperties(string pairsPropertiesPath, string dcaPropertiesPath, string indicatorsPropertiesPath)
     {
-      if (this.ProfitTrailerMajorVersion == 1)
-      {
-        // Load current PT properties from files (Valid for PT 1.x)
-        this.Log.DoLogInfo("Loading current Profit Trailer properties from files...");
+      // Load current PT properties from API (Valid for PT 2.x and above)
+      this.Log.DoLogInfo("Loading current Profit Trailer properties from API...");
 
-        this.PairsLines = File.ReadLines(pairsPropertiesPath).ToList();
-        this.DCALines = File.ReadLines(dcaPropertiesPath).ToList();
-        this.IndicatorsLines = File.ReadLines(indicatorsPropertiesPath).ToList();
-      }
-      else
-      {
-        // Load current PT properties from API (Valid for PT 2.x and above)
-        this.Log.DoLogInfo("Loading current Profit Trailer properties from API...");
-
-        this.PairsLines = SettingsAPI.GetPropertyLinesFromAPI("PAIRS", this.PTMagicConfiguration, this.Log);
-        this.DCALines = SettingsAPI.GetPropertyLinesFromAPI("DCA", this.PTMagicConfiguration, this.Log);
-        this.IndicatorsLines = SettingsAPI.GetPropertyLinesFromAPI("INDICATORS", this.PTMagicConfiguration, this.Log);
-      }
+      this.PairsLines = SettingsAPI.GetPropertyLinesFromAPI("PAIRS", this.PTMagicConfiguration, this.Log);
+      this.DCALines = SettingsAPI.GetPropertyLinesFromAPI("DCA", this.PTMagicConfiguration, this.Log);
+      this.IndicatorsLines = SettingsAPI.GetPropertyLinesFromAPI("INDICATORS", this.PTMagicConfiguration, this.Log);
 
       if (this.PairsLines != null && this.DCALines != null && this.IndicatorsLines != null)
       {
@@ -1170,8 +1059,6 @@ namespace Core.Main
 
       // Get market from PT properties
       this.LastRuntimeSummary.MainMarket = SettingsHandler.GetMainMarket(this.PTMagicConfiguration, this.PairsLines, this.Log);
-
-      this.LastRuntimeSummary.ProfitTrailerMajorVersion = this.ProfitTrailerMajorVersion;
     }
 
     private void LoadSMSSummaries()
@@ -1269,18 +1156,11 @@ namespace Core.Main
       }
       else
       {
-        if (this.ProfitTrailerMajorVersion == 1)
+        // Since PT 2.0 the main market is no longer included in the market list so we need to rebuild the list
+        List<string> originalMarketList = SystemHelper.ConvertTokenStringToList(marketPairs, ",");
+        foreach (string market in originalMarketList)
         {
-          this.MarketList = SystemHelper.ConvertTokenStringToList(marketPairs, ",");
-        }
-        else
-        {
-          // Since PT 2.0 the main market is no longer included in the market list so we need to rebuild the list
-          List<string> originalMarketList = SystemHelper.ConvertTokenStringToList(marketPairs, ",");
-          foreach (string market in originalMarketList)
-          {
-            this.MarketList.Add(SystemHelper.GetFullMarketName(this.LastRuntimeSummary.MainMarket, market, this.PTMagicConfiguration.GeneralSettings.Application.Exchange));
-          }
+          this.MarketList.Add(SystemHelper.GetFullMarketName(this.LastRuntimeSummary.MainMarket, market, this.PTMagicConfiguration.GeneralSettings.Application.Exchange));
         }
       }
     }
@@ -2068,38 +1948,13 @@ namespace Core.Main
     {
       if (headerLinesAdded || this.GlobalSettingWritten || this.SingleMarketSettingWritten)
       {
-        if (this.ProfitTrailerMajorVersion == 1)
-        {
-          // Save current PT properties to files (Valid for PT 1.x)
-          this.Log.DoLogInfo("Saving properties files...");
+        // Save current PT properties to API (Valid for PT 2.x and above)
+        this.Log.DoLogInfo("Saving properties using API...");
 
-          // Write Pairs.properties
-          if (this.PTMagicConfiguration.GeneralSettings.Backup.IsEnabled) FileHelper.CreateBackup(pairsPropertiesPath, this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + "_backups" + Path.DirectorySeparatorChar);
-          this.Log.DoLogInfo("Writing Pairs.properties...");
-          if (!this.PTMagicConfiguration.GeneralSettings.Application.TestMode) File.WriteAllLines(pairsPropertiesPath, this.PairsLines);
+        // Send all Properties
+        if (!this.PTMagicConfiguration.GeneralSettings.Application.TestMode) SettingsAPI.SendPropertyLinesToAPI(this.PairsLines, this.DCALines, this.IndicatorsLines, this.PTMagicConfiguration, this.Log);
 
-          // Write DCA.properties
-          if (this.PTMagicConfiguration.GeneralSettings.Backup.IsEnabled) FileHelper.CreateBackup(dcaPropertiesPath, this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + "_backups" + Path.DirectorySeparatorChar);
-          this.Log.DoLogInfo("Writing DCA.properties...");
-          if (!this.PTMagicConfiguration.GeneralSettings.Application.TestMode) File.WriteAllLines(dcaPropertiesPath, this.DCALines);
-
-          // Write Indicators.properties
-          if (this.PTMagicConfiguration.GeneralSettings.Backup.IsEnabled) FileHelper.CreateBackup(indicatorsPropertiesPath, this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + "_backups" + Path.DirectorySeparatorChar);
-          this.Log.DoLogInfo("Writing Indicators.properties...");
-          if (!this.PTMagicConfiguration.GeneralSettings.Application.TestMode) File.WriteAllLines(indicatorsPropertiesPath, this.IndicatorsLines);
-
-          this.Log.DoLogInfo("All properties files saved!");
-        }
-        else
-        {
-          // Save current PT properties to API (Valid for PT 2.x and above)
-          this.Log.DoLogInfo("Saving properties using API...");
-
-          // Send all Properties
-          if (!this.PTMagicConfiguration.GeneralSettings.Application.TestMode) SettingsAPI.SendPropertyLinesToAPI(this.PairsLines, this.DCALines, this.IndicatorsLines, this.PTMagicConfiguration, this.Log);
-
-          this.Log.DoLogInfo("Properties saved!");
-        }
+        this.Log.DoLogInfo("Properties saved!");
       }
       else
       {
@@ -2315,32 +2170,26 @@ namespace Core.Main
       }
 
       // Get configured DCA percentages
-      if (this.ProfitTrailerMajorVersion >= 2)
+
+      string dcaDefaultPercentageString = SettingsHandler.GetCurrentPropertyValue(dcaProperties, "DEFAULT_DCA_buy_percentage", "");
+      double dcaDefaultPercentage = SystemHelper.TextToDouble(dcaDefaultPercentageString, 0, "en-US");
+
+      this.LastRuntimeSummary.DCAPercentage = dcaDefaultPercentage;
+
+      for (int dca = 1; dca <= maxDCALevel; dca++)
       {
-        string dcaDefaultPercentageString = SettingsHandler.GetCurrentPropertyValue(dcaProperties, "DEFAULT_DCA_buy_percentage", "");
-        double dcaDefaultPercentage = SystemHelper.TextToDouble(dcaDefaultPercentageString, 0, "en-US");
-
-        this.LastRuntimeSummary.DCAPercentage = dcaDefaultPercentage;
-
-        for (int dca = 1; dca <= maxDCALevel; dca++)
+        string dcaPercentageString = SettingsHandler.GetCurrentPropertyValue(dcaProperties, "DEFAULT_DCA_buy_percentage_" + dca.ToString(), "");
+        if (!dcaPercentageString.Equals(""))
         {
-          string dcaPercentageString = SettingsHandler.GetCurrentPropertyValue(dcaProperties, "DEFAULT_DCA_buy_percentage_" + dca.ToString(), "");
-          if (!dcaPercentageString.Equals(""))
-          {
-            double dcaPercentage = SystemHelper.TextToDouble(dcaPercentageString, 0, "en-US");
+          double dcaPercentage = SystemHelper.TextToDouble(dcaPercentageString, 0, "en-US");
 
-            this.LastRuntimeSummary.DCAPercentages.Add(dca, dcaPercentage);
-          }
-          else
-          {
-            if (this.LastRuntimeSummary.DCALevels == 0) this.LastRuntimeSummary.DCALevels = dca - 1;
-            break;
-          }
+          this.LastRuntimeSummary.DCAPercentages.Add(dca, dcaPercentage);
         }
-      }
-      else
-      {
-        this.LastRuntimeSummary.DCAPercentage = 100;
+        else
+        {
+          if (this.LastRuntimeSummary.DCALevels == 0) this.LastRuntimeSummary.DCALevels = dca - 1;
+          break;
+        }
       }
 
       // Get configured Buy Strategies
@@ -2588,7 +2437,6 @@ namespace Core.Main
       {
         this.Log.DoLogWarn("+ Your version is out of date! The most recent version is " + this.LatestVersion);
       }
-      this.Log.DoLogInfo("+ Proft Trailer Major Version: " + PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerMajorVersion.ToString());
       this.Log.DoLogInfo("+ Instance name: " + PTMagicConfiguration.GeneralSettings.Application.InstanceName);
       this.Log.DoLogInfo("+ Time spent: " + SystemHelper.GetProperDurationTime(elapsedSeconds));
       this.Log.DoLogInfo("+ Active setting: " + this.LastRuntimeSummary.CurrentGlobalSetting.SettingName);

--- a/Core/MarketAnalyzer/CoinMarketCap.cs
+++ b/Core/MarketAnalyzer/CoinMarketCap.cs
@@ -17,7 +17,7 @@ namespace Core.MarketAnalyzer
       string result = "";
       try
       {
-        string baseUrl = "https://pro-api.coinmarketcap.com/v1/cryptocurrency/listings/latest?limit=200";
+        string baseUrl = "https://sandbox-api.coinmarketcap.com/v1/cryptocurrency/listings/latest?limit=200";
         string cmcAPI = systemConfiguration.GeneralSettings.Application.CoinMarketCapAPIKey;
 
         log.DoLogInfo("CoinMarketCap - Getting market data...");
@@ -34,7 +34,6 @@ namespace Core.MarketAnalyzer
 
             for (int i = 0; i < jsonObject["data"].Count; i++)
             {
-
               if (jsonObject["data"][i]["quote"]["USD"] != null)
               {
                 Market market = new Market();

--- a/Core/MarketAnalyzer/CoinMarketCap.cs
+++ b/Core/MarketAnalyzer/CoinMarketCap.cs
@@ -17,7 +17,7 @@ namespace Core.MarketAnalyzer
       string result = "";
       try
       {
-        string baseUrl = "https://sandbox-api.coinmarketcap.com/v1/cryptocurrency/listings/latest?limit=200";
+        string baseUrl = "https://pro-api.coinmarketcap.com/v1/cryptocurrency/listings/latest?limit=200";
         string cmcAPI = systemConfiguration.GeneralSettings.Application.CoinMarketCapAPIKey;
 
         log.DoLogInfo("CoinMarketCap - Getting market data...");

--- a/Core/ProfitTrailer/SettingsAPI.cs
+++ b/Core/ProfitTrailer/SettingsAPI.cs
@@ -17,6 +17,36 @@ namespace Core.ProfitTrailer
 {
   public static class SettingsAPI
   {
+    public static void GetInitialProfitTrailerSettings(PTMagicConfiguration systemConfiguration)
+    {
+      string html = "";
+      string url = systemConfiguration.GeneralSettings.Application.ProfitTrailerMonitorURL + "api/data?token=" + systemConfiguration.GeneralSettings.Application.ProfitTrailerServerAPIToken;
+
+      try
+      {
+        HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
+        request.AutomaticDecompression = DecompressionMethods.GZip;
+
+        WebResponse response = request.GetResponse();
+        Stream dataStream = response.GetResponseStream();
+        StreamReader reader = new StreamReader(dataStream);
+        html = reader.ReadToEnd();
+        reader.Close();
+        response.Close();
+
+      }
+      catch (System.Exception)
+      {
+        throw;
+      }
+
+      dynamic json = JsonConvert.DeserializeObject(html);
+
+      systemConfiguration.GeneralSettings.Application.Exchange = json.exchange;
+      systemConfiguration.GeneralSettings.Application.TimezoneOffset = json.timeZoneOffset;
+      systemConfiguration.GeneralSettings.Application.StartBalance = json.startBalance;
+      systemConfiguration.GeneralSettings.Application.MainFiatCurrency = json.settings.currency;
+    }
     public static List<string> GetPropertyLinesFromAPI(string ptFileName, PTMagicConfiguration systemConfiguration, LogHelper log)
     {
       List<string> result = null;

--- a/Core/ProfitTrailer/SettingsHandler.cs
+++ b/Core/ProfitTrailer/SettingsHandler.cs
@@ -436,9 +436,9 @@ namespace Core.ProfitTrailer
             ptmagicInstance.Log.DoLogInfo("Built single market settings '" + setting.SettingName + "' for '" + marketPair + "'.");
           }
 
-          newPairsLines = SettingsHandler.BuildPropertyLinesForSingleMarketSetting(ptmagicInstance.ProfitTrailerMajorVersion, ptmagicInstance.LastRuntimeSummary.MainMarket, marketPair, ptmagicInstance.TriggeredSingleMarketSettings[marketPair], pairsPropertiesToApply, matchedTriggers, globalPairsProperties, newPairsLines, ptmagicInstance.PTMagicConfiguration, ptmagicInstance.Log);
-          newDCALines = SettingsHandler.BuildPropertyLinesForSingleMarketSetting(ptmagicInstance.ProfitTrailerMajorVersion, ptmagicInstance.LastRuntimeSummary.MainMarket, marketPair, ptmagicInstance.TriggeredSingleMarketSettings[marketPair], dcaPropertiesToApply, matchedTriggers, globalDCAProperties, newDCALines, ptmagicInstance.PTMagicConfiguration, ptmagicInstance.Log);
-          newIndicatorsLines = SettingsHandler.BuildPropertyLinesForSingleMarketSetting(ptmagicInstance.ProfitTrailerMajorVersion, ptmagicInstance.LastRuntimeSummary.MainMarket, marketPair, ptmagicInstance.TriggeredSingleMarketSettings[marketPair], indicatorsPropertiesToApply, matchedTriggers, globalIndicatorsProperties, newIndicatorsLines, ptmagicInstance.PTMagicConfiguration, ptmagicInstance.Log);
+          newPairsLines = SettingsHandler.BuildPropertyLinesForSingleMarketSetting(ptmagicInstance.LastRuntimeSummary.MainMarket, marketPair, ptmagicInstance.TriggeredSingleMarketSettings[marketPair], pairsPropertiesToApply, matchedTriggers, globalPairsProperties, newPairsLines, ptmagicInstance.PTMagicConfiguration, ptmagicInstance.Log);
+          newDCALines = SettingsHandler.BuildPropertyLinesForSingleMarketSetting(ptmagicInstance.LastRuntimeSummary.MainMarket, marketPair, ptmagicInstance.TriggeredSingleMarketSettings[marketPair], dcaPropertiesToApply, matchedTriggers, globalDCAProperties, newDCALines, ptmagicInstance.PTMagicConfiguration, ptmagicInstance.Log);
+          newIndicatorsLines = SettingsHandler.BuildPropertyLinesForSingleMarketSetting(ptmagicInstance.LastRuntimeSummary.MainMarket, marketPair, ptmagicInstance.TriggeredSingleMarketSettings[marketPair], indicatorsPropertiesToApply, matchedTriggers, globalIndicatorsProperties, newIndicatorsLines, ptmagicInstance.PTMagicConfiguration, ptmagicInstance.Log);
         }
 
         // Combine global settings lines with single market settings lines
@@ -457,7 +457,7 @@ namespace Core.ProfitTrailer
       }
     }
 
-    public static List<string> BuildPropertyLinesForSingleMarketSetting(int ptMajorVersion, string mainMarket, string marketPair, List<SingleMarketSetting> appliedSettings, Dictionary<string, object> properties, Dictionary<string, List<string>> matchedTriggers, Dictionary<string, string> fullProperties, List<string> newPropertyLines, PTMagicConfiguration systemConfiguration, LogHelper log)
+    public static List<string> BuildPropertyLinesForSingleMarketSetting(string mainMarket, string marketPair, List<SingleMarketSetting> appliedSettings, Dictionary<string, object> properties, Dictionary<string, List<string>> matchedTriggers, Dictionary<string, string> fullProperties, List<string> newPropertyLines, PTMagicConfiguration systemConfiguration, LogHelper log)
     {
       if (properties.Keys.Count > 0)
       {
@@ -499,11 +499,9 @@ namespace Core.ProfitTrailer
           }
 
           string propertyMarketName = marketPair;
-          if (ptMajorVersion > 1)
-          {
-            // Adjust market pair name for PT 2.0 and above
-            propertyMarketName = propertyMarketName.Replace(mainMarket, "").Replace("_", "").Replace("-", "");
-          }
+
+          // Adjust market pair name
+          propertyMarketName = propertyMarketName.Replace(mainMarket, "").Replace("_", "").Replace("-", "");
 
           string propertyKeyString = "";
           if (propertyKey.StartsWith("ALL", StringComparison.InvariantCultureIgnoreCase))

--- a/Monitor/Pages/BagAnalyzer.cshtml.cs
+++ b/Monitor/Pages/BagAnalyzer.cshtml.cs
@@ -21,7 +21,7 @@ namespace Monitor.Pages
 
     private void BindData()
     {
-      PTData = new ProfitTrailerData(PTMagicBasePath, PTMagicConfiguration);
+      PTData = new ProfitTrailerData(PTMagicConfiguration);
     }
   }
 }

--- a/Monitor/Pages/BuyAnalyzer.cshtml.cs
+++ b/Monitor/Pages/BuyAnalyzer.cshtml.cs
@@ -21,7 +21,7 @@ namespace Monitor.Pages
 
     private void BindData()
     {
-      PTData = new ProfitTrailerData(PTMagicBasePath, PTMagicConfiguration);
+      PTData = new ProfitTrailerData(PTMagicConfiguration);
     }
   }
 }

--- a/Monitor/Pages/DCACalculator.cshtml
+++ b/Monitor/Pages/DCACalculator.cshtml
@@ -9,10 +9,7 @@
 }
 
 @{
-  string maxCostCaption = "Max";
-  if (Model.Summary.ProfitTrailerMajorVersion > 1) {
-    maxCostCaption = "Initial";
-  }
+  string maxCostCaption = "Initial";
 }
 
 <div class="row">

--- a/Monitor/Pages/DCACalculator.cshtml.cs
+++ b/Monitor/Pages/DCACalculator.cshtml.cs
@@ -19,7 +19,7 @@ namespace Monitor.Pages
 
     private void BindData()
     {
-      PTData = new ProfitTrailerData(PTMagicBasePath, PTMagicConfiguration);
+      PTData = new ProfitTrailerData(PTMagicConfiguration);
     }
   }
 }

--- a/Monitor/Pages/SalesAnalyzer.cshtml.cs
+++ b/Monitor/Pages/SalesAnalyzer.cshtml.cs
@@ -29,7 +29,7 @@ namespace Monitor.Pages
 
     private void BindData()
     {
-      PTData = new ProfitTrailerData(PTMagicBasePath, PTMagicConfiguration);
+      PTData = new ProfitTrailerData(PTMagicConfiguration);
 
       // Convert local offset time to UTC
       TimeSpan offsetTimeSpan = TimeSpan.Parse(PTMagicConfiguration.GeneralSettings.Application.TimezoneOffset.Replace("+", ""));

--- a/Monitor/Pages/SettingsGeneral.cshtml
+++ b/Monitor/Pages/SettingsGeneral.cshtml
@@ -62,13 +62,6 @@
               </div>
 
               <div class="form-group row">
-                <label class="col-md-4 col-form-label">Profit Trailer Major Version <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Major version of your Profit Trailer."></i></label>
-                <div class="col-md-8">
-                  @Model.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerMajorVersion
-                </div>
-              </div>
-
-              <div class="form-group row">
                 <label class="col-md-4 col-form-label">Profit Trailer Path <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Path to your Profit Trailer main directory."></i></label>
                 <div class="col-md-8">
                   @Model.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath
@@ -93,33 +86,6 @@
                 <label class="col-md-4 col-form-label">Profit Trailer Default Setting Name <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Your Profit Trailer default setting name (needed to change your settings for PT 2.0 and above)"></i></label>
                 <div class="col-md-8">
                   @Model.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerDefaultSettingName
-                </div>
-              </div>
-
-              <div class="form-group row">
-                <label class="col-md-4 col-form-label">Exchange <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="The exchange your are running Profit Trailer on."></i></label>
-                <div class="col-md-8">
-                  <select name="Application_Exchange" class="form-control">
-                    <option selected="@(Model.PTMagicConfiguration.GeneralSettings.Application.Exchange.Equals("Binance", StringComparison.InvariantCultureIgnoreCase))">Binance</option>
-                    <option selected="@(Model.PTMagicConfiguration.GeneralSettings.Application.Exchange.Equals("Bittrex", StringComparison.InvariantCultureIgnoreCase))">Bittrex</option>
-                    <option selected="@(Model.PTMagicConfiguration.GeneralSettings.Application.Exchange.Equals("Poloniex", StringComparison.InvariantCultureIgnoreCase))">Poloniex</option>
-                  </select>
-                </div>
-              </div>
-
-              <div class="form-group row">
-                <label class="col-md-4 col-form-label">Start Balance <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="The balance you had in your wallet when you started working with Profit Trailer."></i></label>
-                <div class="col-md-8">
-                  <input type="text" class="form-control" name="Application_StartBalance" value="@Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance.ToString(new System.Globalization.CultureInfo("en-US"))">
-                </div>
-              </div>
-
-              <div class="form-group row">
-                <label class="col-md-4 col-form-label">Timezone Offset <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Your timezone offset from GMT."></i></label>
-                <div class="col-md-8">
-                  <select name="Application_TimezoneOffset" class="form-control">
-                    @Html.Raw(Model.GetTimezoneSelection())
-                  </select>
                 </div>
               </div>
 

--- a/Monitor/Pages/StatusSummary.cshtml
+++ b/Monitor/Pages/StatusSummary.cshtml
@@ -69,10 +69,7 @@
     <div class="card-box">
       <h4 class="m-t-0 header-title">Active Settings</h4>
       @{
-        string maxCostCaption = "Max";
-        if (Model.Summary.ProfitTrailerMajorVersion > 1) {
-          maxCostCaption = "Initial";
-        }
+        string maxCostCaption = "Initial";
       }
 
       <table class="table table-striped table-sm">

--- a/Monitor/Pages/_get/BagDetails.cshtml.cs
+++ b/Monitor/Pages/_get/BagDetails.cshtml.cs
@@ -24,7 +24,7 @@ namespace Monitor.Pages {
     private void BindData() {
       DCAMarket = GetStringParameter("m", "");
 
-      PTData = new ProfitTrailerData(PTMagicBasePath, PTMagicConfiguration);
+      PTData = new ProfitTrailerData(PTMagicConfiguration);
 
       DCALogData = PTData.DCALog.Find(d => d.Market == DCAMarket);
 

--- a/Monitor/Pages/_get/BagList.cshtml.cs
+++ b/Monitor/Pages/_get/BagList.cshtml.cs
@@ -23,7 +23,7 @@ namespace Monitor.Pages {
       SortFieldId = GetStringParameter("s", "ProfitPercent");
       SortDirection = GetStringParameter("d", "DESC");
 
-      PTData = new ProfitTrailerData(PTMagicBasePath, PTMagicConfiguration);
+      PTData = new ProfitTrailerData(PTMagicConfiguration);
     }
   }
 }

--- a/Monitor/Pages/_get/BuyList.cshtml.cs
+++ b/Monitor/Pages/_get/BuyList.cshtml.cs
@@ -23,7 +23,7 @@ namespace Monitor.Pages {
       SortFieldId = GetStringParameter("s", "ProfitPercent");
       SortDirection = GetStringParameter("d", "DESC");
 
-      PTData = new ProfitTrailerData(PTMagicBasePath, PTMagicConfiguration);
+      PTData = new ProfitTrailerData(PTMagicConfiguration);
     }
   }
 }

--- a/Monitor/Pages/_get/DashboardBottom.cshtml.cs
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml.cs
@@ -25,7 +25,7 @@ namespace Monitor.Pages {
     }
 
     private void BindData() {
-      PTData = new ProfitTrailerData(PTMagicBasePath, PTMagicConfiguration);
+      PTData = new ProfitTrailerData(PTMagicConfiguration);
 
       // Cleanup temp files
       FileHelper.CleanupFilesMinutes(PTMagicMonitorBasePath + "wwwroot" + System.IO.Path.DirectorySeparatorChar + "assets" + System.IO.Path.DirectorySeparatorChar + "tmp" + System.IO.Path.DirectorySeparatorChar, 5);

--- a/Monitor/Pages/_get/DashboardTop.cshtml.cs
+++ b/Monitor/Pages/_get/DashboardTop.cshtml.cs
@@ -20,7 +20,7 @@ namespace Monitor.Pages {
     }
 
     private void BindData() {
-      PTData = new ProfitTrailerData(PTMagicBasePath, PTMagicConfiguration);
+      PTData = new ProfitTrailerData(PTMagicConfiguration);
 
       // Convert local offset time to UTC
       TimeSpan offsetTimeSpan = TimeSpan.Parse(PTMagicConfiguration.GeneralSettings.Application.TimezoneOffset.Replace("+", ""));

--- a/Monitor/Pages/_get/SalesList.cshtml.cs
+++ b/Monitor/Pages/_get/SalesList.cshtml.cs
@@ -29,7 +29,7 @@ namespace Monitor.Pages {
       salesDateString = GetStringParameter("d", "");
       salesMonthString = GetStringParameter("m", "");
 
-      PTData = new ProfitTrailerData(PTMagicBasePath, PTMagicConfiguration);
+      PTData = new ProfitTrailerData(PTMagicConfiguration);
 
       if (!salesDateString.Equals("")) {
         SalesDate = SystemHelper.TextToDateTime(salesDateString, Constants.confMinDate);

--- a/Monitor/Pages/_get/TickerWidgets.cshtml.cs
+++ b/Monitor/Pages/_get/TickerWidgets.cshtml.cs
@@ -20,7 +20,7 @@ namespace Monitor.Pages {
     }
 
     private void BindData() {
-      PTData = new ProfitTrailerData(PTMagicBasePath, PTMagicConfiguration);
+      PTData = new ProfitTrailerData(PTMagicConfiguration);
 
       // Get markets with active single settings
       foreach (string key in Summary.MarketSummary.Keys) {

--- a/PTMagic/_defaults/_default settings PT 2.x/_default settings BTC or ETH/settings.general.json
+++ b/PTMagic/_defaults/_default settings PT 2.x/_default settings BTC or ETH/settings.general.json
@@ -3,15 +3,11 @@
     "Application": {
       "IsEnabled": true, // Enables the PTMagic bot (needs restart to take effect)
       "TestMode": false, // If TestMode is active, no properties files will be changed
-      "ProfitTrailerMajorVersion": 2, // Major version of your Profit Trailer (If you are using 1.2.x the major version is "1", if you are using 2.x the major version is "2" and so on)
       "ProfitTrailerPath": "YOUR PROFIT TRAILER PATH", // Path to your Profit Trailer main directory (use double backslashes for windows like C:\\ProfitTrailer\\)
       "ProfitTrailerLicense": "YOUR PROFIT TRAILER LICENSE KEY", // Your Profit Trailer license key (needed to change your settings for PT 2.0 and above)
+      "ProfitTrailerServerAPIToken": "", //Your Profit Trailer Server API Token
       "ProfitTrailerMonitorURL": "http://localhost:8081/", // The URL to your profit trailer monitor (needed to change your settings for PT 2.0 and above)
       "ProfitTrailerDefaultSettingName": "default", // Your Profit Trailer default setting name (needed to change your settings for PT 2.0 and above)
-      "Exchange": "Bittrex", // The exchange your are running Profit Trailer on
-      "StartBalance": 0, // The balance you had in your wallet when you started working with Profit Trailer
-      "TimezoneOffset": "+0:00", // Your timezone offset from UTC time
-      "MainFiatCurrency": "USD", // Your main fiat currency that will be used in the monitor
       "AlwaysLoadDefaultBeforeSwitch": true, // If this is enabled, PTMagic will always load default settings before switching to another setting
       "FloodProtectionMinutes": 15, // If a price trend is just zig-zagging around its trigger, you may want to protect your settings from getting switched back and forth every minute
       "InstanceName": "PT Magic", // The name of the instance of this bot. This will be used in your monitor and your Telegram messages. In case you are running more than one bot, you may set different names to separate them

--- a/PTMagic/_defaults/_default settings PT 2.x/_default settings USDT/settings.general.json
+++ b/PTMagic/_defaults/_default settings PT 2.x/_default settings USDT/settings.general.json
@@ -3,15 +3,11 @@
     "Application": {
       "IsEnabled": true, // Enables the PTMagic bot (needs restart to take effect)
       "TestMode": false, // If TestMode is active, no properties files will be changed
-      "ProfitTrailerMajorVersion": 2, // Major version of your Profit Trailer (If you are using 1.2.x the major version is "1", if you are using 2.x the major version is "2" and so on)
       "ProfitTrailerPath": "YOUR PROFIT TRAILER PATH", // Path to your Profit Trailer main directory (use double backslashes for windows like C:\\ProfitTrailer\\)
       "ProfitTrailerLicense": "YOUR PROFIT TRAILER LICENSE KEY", // Your Profit Trailer license key (needed to change your settings for PT 2.0 and above)
+      "ProfitTrailerServerAPIToken": "", //Your Profit Trailer Server API Token
       "ProfitTrailerMonitorURL": "http://localhost:8081/", // The URL to your profit trailer monitor (needed to change your settings for PT 2.0 and above)
       "ProfitTrailerDefaultSettingName": "default", // Your Profit Trailer default setting name (needed to change your settings for PT 2.0 and above)
-      "Exchange": "Bittrex", // The exchange your are running Profit Trailer on
-      "StartBalance": 0, // The balance you had in your wallet when you started working with Profit Trailer
-      "TimezoneOffset": "+0:00", // Your timezone offset from UTC time
-      "MainFiatCurrency": "USD", // Your main fiat currency that will be used in the monitor
       "AlwaysLoadDefaultBeforeSwitch": true, // If this is enabled, PTMagic will always load default settings before switching to another setting
       "FloodProtectionMinutes": 15, // If a price trend is just zig-zagging around its trigger, you may want to protect your settings from getting switched back and forth every minute
       "InstanceName": "PT Magic", // The name of the instance of this bot. This will be used in your monitor and your Telegram messages. In case you are running more than one bot, you may set different names to separate them

--- a/_Development/DevSettings/settings.general.json
+++ b/_Development/DevSettings/settings.general.json
@@ -3,15 +3,11 @@
     "Application": {
       "IsEnabled": true, // Enables the PTMagic bot (needs restart to take effect)
       "TestMode": false, // If TestMode is active, no properties files will be changed
-      "ProfitTrailerMajorVersion": 2, // Major version of your Profit Trailer (If you are using 1.2.x the major version is "1", if you are using 2.x the major version is "2" and so on)
       "ProfitTrailerPath": "YOUR PROFIT TRAILER PATH", // Path to your Profit Trailer main directory (use double backslashes for windows like C:\\ProfitTrailer\\)
       "ProfitTrailerLicense": "YOUR PROFIT TRAILER LICENSE KEY", // Your Profit Trailer license key (needed to change your settings for PT 2.0 and above)
+      "ProfitTrailerServerAPIToken": "", //Your Profit Trailer Server API Token
       "ProfitTrailerMonitorURL": "http://localhost:8081/", // The URL to your profit trailer monitor (needed to change your settings for PT 2.0 and above)
       "ProfitTrailerDefaultSettingName": "default", // Your Profit Trailer default setting name (needed to change your settings for PT 2.0 and above)
-      "Exchange": "Bittrex", // The exchange your are running Profit Trailer on
-      "StartBalance": 0, // The balance you had in your wallet when you started working with Profit Trailer
-      "TimezoneOffset": "+0:00", // Your timezone offset from UTC time
-      "MainFiatCurrency": "USD", // Your main fiat currency that will be used in the monitor
       "AlwaysLoadDefaultBeforeSwitch": true, // If this is enabled, PTMagic will always load default settings before switching to another setting
       "FloodProtectionMinutes": 15, // If a price trend is just zig-zagging around its trigger, you may want to protect your settings from getting switched back and forth every minute
       "InstanceName": "PT Magic", // The name of the instance of this bot. This will be used in your monitor and your Telegram messages. In case you are running more than one bot, you may set different names to separate them


### PR DESCRIPTION
So this PR contains a lot of changes.

Removed the backwards compatibility with PT1.
The below settings are now removed from the settings file as this data now gets pulled via API.
      "Exchange": "Bittrex",
      "StartBalance": 0, 
      "TimezoneOffset": "+0:00",
      "MainFiatCurrency": "USD",

Added a new Setting to the settingsfile:
      "ProfitTrailerServerAPIToken"
This has to be set to the same string in pt and ptm to allow comunication.

ProfitTrailerData is now being pulled via API and not via the file anymore. That's because this file doesn't exist anymore in PT2.2

PTM Functionality should work with PT2.2(Testing needed). Most Monitor pages are still not working. 
PT did some changes with the structure of their data. I already did some modifications but those data structure changes are most likely the cause of the monitor bugs.

Feel free to help fix those bugs ;)
