### PR TITLE
Removed SMS Trigger Comments

### DIFF
--- a/Core/ProfitTrailer/SettingsHandler.cs
+++ b/Core/ProfitTrailer/SettingsHandler.cs
@@ -469,11 +469,6 @@ namespace Core.ProfitTrailer
         }
 
         newPropertyLines.Add("# " + marketPair + " - Current active settings: " + appliedSettingsStringList);
-        newPropertyLines.Add("# Matching triggers:");
-        foreach (string matchingTrigger in matchedTriggers[marketPair])
-        {
-          newPropertyLines.Add("# " + matchingTrigger);
-        }
 
         foreach (string settingProperty in properties.Keys)
         {


### PR DESCRIPTION
Removed auto-generated comments detailng specific trigger conditions from SMS, to help reduce file size.

PT2.2b34 has stricter size limitations for settings files.

Current SMS setting comments remain.