### PR TITLE
Minor Fixes

### DIFF
--- a/Core/DataObjects/PTMagicData.cs
+++ b/Core/DataObjects/PTMagicData.cs
@@ -48,6 +48,7 @@ namespace Core.Main.DataObjects.PTMagicData
     public string TimezoneOffset { get; set; } = "+0:00";
     public string MainFiatCurrency { get; set; } = "USD";
     public string CoinMarketCapAPIKey { get; set; }
+    public string FreeCurrencyConverterAPIKey { get; set; }
   }
 
   public class Monitor

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -560,6 +560,7 @@ namespace Core.Main
       SettingsFiles.CheckPresets(this.PTMagicConfiguration, this.Log, true);
 
       EnforceSettingsReapply = true;
+      
       this.StartPTMagicIntervalTimer();
 
       return result;
@@ -798,7 +799,9 @@ namespace Core.Main
         this.RunCount++;
 
         bool headerLinesAdded = false;
-        this.EnforceSettingsReapply = this.HaveSettingsChanged();
+
+        // Force update from preset files with every run
+        this.EnforceSettingsReapply = true; // = this.HaveSettingsChanged();
 
         if (PTMagicConfiguration.GeneralSettings.Application.IsEnabled)
         {

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -670,6 +670,16 @@ namespace Core.Main
         {
           this.Log.DoLogInfo("No CoinMarketCap API KEY specified! You can't use CoinMarketCap in your settings.analyzer.json");
         }
+
+        // Check for CurrencyConverterApi Key
+        if (!this.PTMagicConfiguration.GeneralSettings.Application.FreeCurrencyConverterAPIKey.Equals(""))
+        {
+          this.Log.DoLogInfo("FreeCurrencyConverterApi KEY found");
+        }
+        else
+        {
+          this.Log.DoLogInfo("No FreeCurrencyConverterApi KEY specified! You can't use non USD Currencies!");
+        }
       }
 
       else
@@ -1021,7 +1031,7 @@ namespace Core.Main
         try
         {
           this.LastRuntimeSummary.MainFiatCurrency = this.PTMagicConfiguration.GeneralSettings.Application.MainFiatCurrency;
-          this.LastRuntimeSummary.MainFiatCurrencyExchangeRate = BaseAnalyzer.GetMainFiatCurrencyRate(this.PTMagicConfiguration.GeneralSettings.Application.MainFiatCurrency, this.Log);
+          this.LastRuntimeSummary.MainFiatCurrencyExchangeRate = BaseAnalyzer.GetMainFiatCurrencyRate(this.PTMagicConfiguration.GeneralSettings.Application.MainFiatCurrency, this.PTMagicConfiguration.GeneralSettings.Application.FreeCurrencyConverterAPIKey, this.Log);
           this.LastMainFiatCurrency = this.LastRuntimeSummary.MainFiatCurrency;
           this.LastMainFiatCurrencyExchangeRate = this.LastRuntimeSummary.MainFiatCurrencyExchangeRate;
 

--- a/Core/MarketAnalyzer/BaseAnalyzer.cs
+++ b/Core/MarketAnalyzer/BaseAnalyzer.cs
@@ -195,11 +195,11 @@ namespace Core.MarketAnalyzer
       return result;
     }
 
-    public static double GetMainFiatCurrencyRate(string currency, LogHelper log)
+    public static double GetMainFiatCurrencyRate(string currency, string FreeCurrencyAPI, LogHelper log)
     {
       double result = 1;
 
-      string baseUrl = "http://free.currencyconverterapi.com/api/v5/convert?q=USD_" + currency + "&compact=y";
+      string baseUrl = "http://free.currencyconverterapi.com/api/v5/convert?q=USD_" + currency + "&compact=y&apiKey="+FreeCurrencyAPI;
 
       log.DoLogDebug("http://free.currencyconverterapi.com - Getting latest exchange rates...");
       Newtonsoft.Json.Linq.JObject jsonObject = GetSimpleJsonObjectFromURL(baseUrl, log, false);

--- a/Monitor/Pages/SettingsGeneral.cshtml.cs
+++ b/Monitor/Pages/SettingsGeneral.cshtml.cs
@@ -74,6 +74,7 @@ namespace Monitor.Pages
       PTMagicConfiguration.GeneralSettings.Application.FloodProtectionMinutes = SystemHelper.TextToInteger(HttpContext.Request.Form["Application_FloodProtectionMinutes"], PTMagicConfiguration.GeneralSettings.Application.FloodProtectionMinutes);
       PTMagicConfiguration.GeneralSettings.Application.InstanceName = HttpContext.Request.Form["Application_InstanceName"];
       PTMagicConfiguration.GeneralSettings.Application.CoinMarketCapAPIKey = HttpContext.Request.Form["Application_CoinMarketCapAPIKey"];
+      PTMagicConfiguration.GeneralSettings.Application.FreeCurrencyConverterAPIKey = HttpContext.Request.Form["Application_FreeCurrencyConverterAPIKey"];
 
       PTMagicConfiguration.GeneralSettings.Monitor.IsPasswordProtected = HttpContext.Request.Form["Monitor_IsPasswordProtected"].Equals("on");
       PTMagicConfiguration.GeneralSettings.Monitor.OpenBrowserOnStart = HttpContext.Request.Form["Monitor_OpenBrowserOnStart"].Equals("on");


### PR DESCRIPTION
- Added FreeCurrencyConverterAPI key fix.
https://free.currencyconverterapi.com/ now requires users to obtain an API via email.
Added a new field to settings.general.json for this value.  It should work if the value is null.
If  "MainFiatCurrency":  is anything other than USD, an API key is required.

- Preset settings files are updated every run. 
Previously, changes to the preset files were only pushed to the API if the global settings changed -- or, if the user deleted the header of the config files in the PT config window exactly between PTM runs.   This made quickly updating settings impractical, often turning into a game of updating settings in multiple places and hoping they stuck.  Now settings can be updated via the local preset files, and they will be pushed every time PTM runs.


