### PR TITLE
CurrencyConverterAPI & AspNetCore Updates

### DIFF
--- a/Core/DataObjects/PTMagicData.cs
+++ b/Core/DataObjects/PTMagicData.cs
@@ -48,6 +48,7 @@ namespace Core.Main.DataObjects.PTMagicData
     public string TimezoneOffset { get; set; } = "+0:00";
     public string MainFiatCurrency { get; set; } = "USD";
     public string CoinMarketCapAPIKey { get; set; }
+    public string FreeCurrencyConverterAPIKey { get; set; }
   }
 
   public class Monitor

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -670,6 +670,16 @@ namespace Core.Main
         {
           this.Log.DoLogInfo("No CoinMarketCap API KEY specified! You can't use CoinMarketCap in your settings.analyzer.json");
         }
+
+         // Check for CurrencyConverterApi Key
+        if (!this.PTMagicConfiguration.GeneralSettings.Application.FreeCurrencyConverterAPIKey.Equals(""))
+        {
+          this.Log.DoLogInfo("FreeCurrencyConverterApi KEY found");
+        }
+        else
+        {
+          this.Log.DoLogInfo("No FreeCurrencyConverterApi KEY specified! You can't use non USD Currencies!");
+        }
       }
 
       else
@@ -1021,7 +1031,7 @@ namespace Core.Main
         try
         {
           this.LastRuntimeSummary.MainFiatCurrency = this.PTMagicConfiguration.GeneralSettings.Application.MainFiatCurrency;
-          this.LastRuntimeSummary.MainFiatCurrencyExchangeRate = BaseAnalyzer.GetMainFiatCurrencyRate(this.PTMagicConfiguration.GeneralSettings.Application.MainFiatCurrency, this.Log);
+          this.LastRuntimeSummary.MainFiatCurrencyExchangeRate = BaseAnalyzer.GetMainFiatCurrencyRate(this.PTMagicConfiguration.GeneralSettings.Application.MainFiatCurrency, this.PTMagicConfiguration.GeneralSettings.Application.FreeCurrencyConverterAPIKey, this.Log);
           this.LastMainFiatCurrency = this.LastRuntimeSummary.MainFiatCurrency;
           this.LastMainFiatCurrencyExchangeRate = this.LastRuntimeSummary.MainFiatCurrencyExchangeRate;
 

--- a/Core/MarketAnalyzer/BaseAnalyzer.cs
+++ b/Core/MarketAnalyzer/BaseAnalyzer.cs
@@ -195,11 +195,11 @@ namespace Core.MarketAnalyzer
       return result;
     }
 
-    public static double GetMainFiatCurrencyRate(string currency, LogHelper log)
+    public static double GetMainFiatCurrencyRate(string currency, string FreeCurrencyAPI, LogHelper log)
     {
       double result = 1;
 
-      string baseUrl = "http://free.currencyconverterapi.com/api/v5/convert?q=USD_" + currency + "&compact=y";
+      string baseUrl = "http://free.currencyconverterapi.com/api/v5/convert?q=USD_" + currency + "&compact=y&apiKey="+FreeCurrencyAPI;
 
       log.DoLogDebug("http://free.currencyconverterapi.com - Getting latest exchange rates...");
       Newtonsoft.Json.Linq.JObject jsonObject = GetSimpleJsonObjectFromURL(baseUrl, log, false);

--- a/Monitor/Monitor.csproj
+++ b/Monitor/Monitor.csproj
@@ -22,10 +22,10 @@
     <Content Include="wwwroot\assets\js\dca.js" CopyToOutputDirectory="Always" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />


### PR DESCRIPTION
- Added FreeCurrencyConverterAPI key fix.
https://free.currencyconverterapi.com/ now requires users to obtain an API via email.
Added a new field to settings.general.json for this value.  It should work if the value is null.
If  "MainFiatCurrency":  is anything other than USD, an API key is required.

- Updated ASPNetCore 
"Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1"
"Microsoft.AspNetCore.All" Version="2.1.7" 
"Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" 
"Newtonsoft.Json" Version="12.0.1"

