### PR TITLE
incorrect buy strats & donate button

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at @Legedric. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team on Discord. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/Core/ProfitTrailer/StrategyHelper.cs
+++ b/Core/ProfitTrailer/StrategyHelper.cs
@@ -271,13 +271,18 @@ namespace Core.ProfitTrailer
     }
 
     public static string GetStrategyText(Summary summary, List<Strategy> strategies, string strategyText, bool isTrue, bool isTrailingBuyActive)
-    {
+    {     
+      bool isValidStrategy = false;
+
       if (strategies.Count > 0)
       {
         foreach (Strategy strategy in strategies)
         {
           string textClass = (strategy.IsTrue) ? "label-success" : "label-danger";
-          if (!StrategyHelper.IsValidStrategy(strategy.Name))
+
+          isValidStrategy = StrategyHelper.IsValidStrategy(strategy.Name);
+
+          if (!isValidStrategy)
           {
             strategyText += "<span class=\"label label-warning\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"" + strategy.Name + "\">" + StrategyHelper.GetStrategyShortcut(strategy.Name, false) + "</span> ";
           }
@@ -305,14 +310,17 @@ namespace Core.ProfitTrailer
         }
         else
         {
-          if (StrategyHelper.IsValidStrategy(strategyText))
+          
+          isValidStrategy = StrategyHelper.IsValidStrategy(strategyText);
+
+          if (isValidStrategy)
           {
             strategyText = "<span class=\"label label-danger\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"" + strategyText + "\">" + StrategyHelper.GetStrategyShortcut(strategyText, true) + "</span>";
           }
-          else if (strategyText.Equals(""))
+          
+          else if (strategyText.Equals("") && isValidStrategy == false)
           {
-            strategyText = summary.DCABuyStrategy;
-            strategyText = "<span class=\"label label-danger\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"" + strategyText + "\">" + StrategyHelper.GetStrategyShortcut(strategyText, true) + "</span>";
+            strategyText = "<span class=\"label label-muted\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"Not Applicable: Not using DCA!\"></span>";
           }
           else
           {

--- a/Monitor/Pages/_Layout.cshtml
+++ b/Monitor/Pages/_Layout.cshtml
@@ -123,8 +123,9 @@
             </li>
 
             <li>
-              <a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerMonitorURL)" target="_blank"><i class="fa fa-desktop fa-2x"></i> <span> PT Monitor <small class="text-muted">(@Html.Raw(Model.Summary.MainMarket + "@" + Model.PTMagicConfiguration.GeneralSettings.Application.Exchange))</small></span></a>
+              <a href="https://github.com/PTMagicians/PTMagic/wiki#donations-1" target="_blank"><i class="fa fa-btc fa-2x"></i> <span>Donate</span></a>
             </li>
+
           </ul>
           <!-- End navigation menu -->
         </div> <!-- end #navigation -->


### PR DESCRIPTION
- https://github.com/PTMagicians/PTMagic/issues/16
fix by @nnation 

- removed menu link to open PT monitor, and replaced it with a "Donate" button that takes the user to the donate section of the PTM wiki.

- updated code of conduct to remove reference to @Legedric 