### PR TITLE
Pairs and DCA, Bag Analyser enhanced to highlight pairs with no value in red

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,11 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-<<<<<<< HEAD
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team on Discord. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
-=======
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at @Hojou. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
->>>>>>> master
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/Monitor/Pages/BagAnalyzer.cshtml
+++ b/Monitor/Pages/BagAnalyzer.cshtml
@@ -29,7 +29,7 @@
           <thead>
             <tr>
               <th data-fieldid="Market" data-tablesaw-sortable-col>Market</th>
-              <th data-fieldid="TotalCost" data-tablesaw-sortable-col data-sortable-numeric="true" class="text-right" data-toggle="tooltip" data-placement="top" title="Spent total cost in @Model.Summary.MainMarket">Value</th>
+              <th data-fieldid="TotalCost" data-tablesaw-sortable-col data-sortable-numeric="true" class="text-left" data-toggle="tooltip" data-placement="top" title="Spent total cost in @Model.Summary.MainMarket">Value</th>
               <th data-fieldid="BoughtTimes" data-tablesaw-sortable-col data-sortable-numeric="true" class="text-right" data-toggle="tooltip" data-placement="top" title="Current DCA level">DCA</th>
               <th data-toggle="tooltip" data-placement="top" title="Active buy strategies">Buy Strats</th>
               <th class="text-right" data-toggle="tooltip" data-placement="top" title="Buy Strategy Value">BS Value</th>

--- a/Monitor/Pages/_get/BagList.cshtml
+++ b/Monitor/Pages/_get/BagList.cshtml
@@ -81,7 +81,7 @@
   lostValue = (dcaLogEntry.TotalCost == 0.0);
 
   // Render the row
-  <tr @(lostValue ? "class=errorRow" : "") >
+  <tr @(lostValue ? "class=errorRow" : "" ) >
     @if (mps != null && (mps.ActiveSingleSettings == null || mps.ActiveSingleSettings.Count == 0)) {
       <th class="align-top"><a href="@Core.Helper.SystemHelper.GetMarketLink(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform,Model.PTMagicConfiguration.GeneralSettings.Application.Exchange, dcaLogEntry.Market, Model.Summary.MainMarket)" target="_blank">@dcaLogEntry.Market</a></th>
     } else {

--- a/Monitor/Pages/_get/BagList.cshtml
+++ b/Monitor/Pages/_get/BagList.cshtml
@@ -11,6 +11,7 @@
 }
 
 @foreach (Core.Main.DataObjects.PTMagicData.DCALogData dcaLogEntry in dcaLogResult) {
+  // Loop through the pairs preparing the data for display
   Core.Main.DataObjects.PTMagicData.MarketPairSummary mps = null;
   if (Model.Summary.MarketSummary.ContainsKey(dcaLogEntry.Market)) {
     mps = Model.Summary.MarketSummary[dcaLogEntry.Market];
@@ -75,13 +76,20 @@
   string triggerSellValueText = Core.ProfitTrailer.StrategyHelper.GetTriggerValueText(Model.Summary, dcaLogEntry.SellStrategies, dcaLogEntry.SellStrategy, dcaLogEntry.BBTrigger, dcaLogEntry.SellTrigger, 0, true);
   double currentFiatValue = Math.Round(dcaLogEntry.Amount * dcaLogEntry.CurrentPrice * Model.Summary.MainMarketPrice, 2);
   
-  <tr>
+  // Check for when PT loses the value of a pair
+  bool lostValue = false;
+  lostValue = (dcaLogEntry.TotalCost == 0.0);
+
+  // Render the row
+  <tr @(lostValue ? "class=errorRow" : "") >
     @if (mps != null && (mps.ActiveSingleSettings == null || mps.ActiveSingleSettings.Count == 0)) {
       <th class="align-top"><a href="@Core.Helper.SystemHelper.GetMarketLink(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform,Model.PTMagicConfiguration.GeneralSettings.Application.Exchange, dcaLogEntry.Market, Model.Summary.MainMarket)" target="_blank">@dcaLogEntry.Market</a></th>
     } else {
       <th class="align-top"><a href="@Core.Helper.SystemHelper.GetMarketLink(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform,Model.PTMagicConfiguration.GeneralSettings.Application.Exchange, dcaLogEntry.Market, Model.Summary.MainMarket)" target="_blank">@dcaLogEntry.Market</a> <i class="fa fa-exclamation-triangle text-highlight" data-toggle="tooltip" data-placement="top" data-html="true" title="@await Component.InvokeAsync("PairIcon", mps)" data-template="<div class='tooltip' role='tooltip'><div class='tooltip-arrow'></div><div class='tooltip-inner pair-tooltip'></div></div>"></i></th>
     }
-    <td class="text-right">@Html.Raw(@dcaLogEntry.TotalCost.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US")) + "(" + Model.MainFiatCurrencySymbol + currentFiatValue.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + ")")</td>
+
+    <td class="text-left">@(!lostValue ? @dcaLogEntry.TotalCost.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US")) + " (" + Model.MainFiatCurrencySymbol + currentFiatValue.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + ")" : "No value!")</td> 
+    
     <td class="text-right">
       @if (dcaLogEntry.BoughtTimes > 0) {
         @dcaLogEntry.BoughtTimes;

--- a/Monitor/Pages/_get/DashboardTop.cshtml
+++ b/Monitor/Pages/_get/DashboardTop.cshtml
@@ -93,6 +93,7 @@
           </thead>
           <tbody>
             @foreach (Core.Main.DataObjects.PTMagicData.DCALogData dcaLogEntry in Model.PTData.DCALog.OrderByDescending(d => d.ProfitPercent).Take(Model.PTMagicConfiguration.GeneralSettings.Monitor.MaxDashboardBagEntries)) {
+              // Loop through the pairs preparing the data for display
               Core.Main.DataObjects.PTMagicData.MarketPairSummary mps = null;
               if (Model.Summary.MarketSummary.ContainsKey(dcaLogEntry.Market)) {
                 mps = Model.Summary.MarketSummary[dcaLogEntry.Market];
@@ -131,14 +132,20 @@
 
               string sellStrategyText = Core.ProfitTrailer.StrategyHelper.GetStrategyText(Model.Summary, dcaLogEntry.SellStrategies, dcaLogEntry.SellStrategy, isSellStrategyTrue, isTrailingSellActive);
 
-              <tr>
+              // Check for when PT loses the value of a pair
+              bool lostValue = false;
+              lostValue = (dcaLogEntry.TotalCost == 0.0);
+
+              // Render the row
+              <tr @(lostValue ? "class=errorRow" : "") >
                 @if (mps == null || mps.ActiveSingleSettings == null || mps.ActiveSingleSettings.Count == 0) {
                   <th class="align-top"><a href="@Core.Helper.SystemHelper.GetMarketLink(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform,Model.PTMagicConfiguration.GeneralSettings.Application.Exchange, dcaLogEntry.Market, Model.Summary.MainMarket)" target="_blank">@dcaLogEntry.Market</a></th>
                 } else {
                   <th class="align-top"><a href="@Core.Helper.SystemHelper.GetMarketLink(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform,Model.PTMagicConfiguration.GeneralSettings.Application.Exchange, dcaLogEntry.Market, Model.Summary.MainMarket)" target="_blank">@dcaLogEntry.Market</a> <i class="fa fa-exclamation-triangle text-highlight" data-toggle="tooltip" data-placement="top" data-html="true" title="@await Component.InvokeAsync("PairIcon", mps)" data-template="<div class='tooltip' role='tooltip'><div class='tooltip-arrow'></div><div class='tooltip-inner pair-tooltip'></div></div>"></i></th>
                 }
                 
-                <td class="text-left">@Html.Raw(dcaLogEntry.TotalCost.ToString("#,#0.000000", new System.Globalization.CultureInfo("en-US")))</td> 
+                <td class="text-left">@(!lostValue ? dcaLogEntry.TotalCost.ToString("#,#0.000000", new System.Globalization.CultureInfo("en-US")) : "No value!")</td>
+                
                 <td class="text-right">
                   @if (dcaEnabled) {
                     @if (dcaLogEntry.BoughtTimes > 0) {

--- a/Monitor/wwwroot/assets/css/custom.css
+++ b/Monitor/wwwroot/assets/css/custom.css
@@ -141,6 +141,16 @@
   display: none;
 }
 
+.errorRow
+{
+  background-color: #550000;
+}
+
+.errorRow a
+{
+  color: white;
+}
+
 .table-scroll-hori {
   display: block;
   width: 100%;
@@ -190,3 +200,4 @@
 #topnav .has-submenu.active > a {
   color: #50cefc;
 }
+


### PR DESCRIPTION
Pairs and DCA, Bag Analyser enhanced to highlight pairs with no value in red. This is to help users notice when PT loses prices which it does occasionally.