### PR TITLE
Fix for issue #72

### DIFF
--- a/Core/ProfitTrailer/SettingsHandler.cs
+++ b/Core/ProfitTrailer/SettingsHandler.cs
@@ -537,11 +537,25 @@ namespace Core.ProfitTrailer
               if (offsetValuePercent != 0)
               {
                 double oldValue = SystemHelper.TextToDouble(SettingsHandler.GetCurrentPropertyValue(fullProperties, propertyKey, propertyKey.Replace("ALL_", "DEFAULT_")), 0, "en-US");
-                if (oldValue < 0) offsetValuePercent = offsetValuePercent * -1;
+
+                if (oldValue < 0)
+                {
+                  offsetValuePercent = offsetValuePercent * -1;
+                }
+
                 double oldValueOffset = (oldValue * (offsetValuePercent / 100));
-                //Round up any decimal value >= .5 
-                int newTempValue = (int)(Math.Round((oldValue + oldValueOffset), MidpointRounding.AwayFromZero) + .5);
-                newValueString = newTempValue.ToString(new System.Globalization.CultureInfo("en-US"));
+
+                if (propertyKey.Contains("Timeout", StringComparison.CurrentCultureIgnoreCase))
+                {
+                  // Ensure timeout values are rounded up to integers for PT comaptability 
+                  newValueString = ((int)(Math.Round((oldValue + oldValueOffset), MidpointRounding.AwayFromZero) + .5)).ToString(new System.Globalization.CultureInfo("en-US"));
+                }
+                else
+                {
+                  // Use double to calculate
+                  newValueString = Math.Round((oldValue + oldValueOffset), 8).ToString(new System.Globalization.CultureInfo("en-US"));
+                }
+
               }
               break;
             default:

--- a/Core/ProfitTrailer/SettingsHandler.cs
+++ b/Core/ProfitTrailer/SettingsHandler.cs
@@ -545,9 +545,9 @@ namespace Core.ProfitTrailer
 
                 double oldValueOffset = (oldValue * (offsetValuePercent / 100));
 
-                if (propertyKey.Contains("Timeout", StringComparison.CurrentCultureIgnoreCase))
+                if (propertyKey.Contains("rebuy_timeout", StringComparison.CurrentCultureIgnoreCase) || (propertyKey.Contains("trading_pairs", StringComparison.CurrentCultureIgnoreCase) )
                 {
-                  // Ensure timeout values are rounded up to integers for PT comaptability 
+                  // Ensure some values are rounded up to integers for PT comaptability 
                   newValueString = ((int)(Math.Round((oldValue + oldValueOffset), MidpointRounding.AwayFromZero) + .5)).ToString(new System.Globalization.CultureInfo("en-US"));
                 }
                 else

--- a/Core/ProfitTrailer/SettingsHandler.cs
+++ b/Core/ProfitTrailer/SettingsHandler.cs
@@ -545,7 +545,7 @@ namespace Core.ProfitTrailer
 
                 double oldValueOffset = (oldValue * (offsetValuePercent / 100));
 
-                if (propertyKey.Contains("rebuy_timeout", StringComparison.CurrentCultureIgnoreCase) || (propertyKey.Contains("trading_pairs", StringComparison.CurrentCultureIgnoreCase) )
+                if (propertyKey.Contains("rebuy_timeout", StringComparison.CurrentCultureIgnoreCase) || propertyKey.Contains("trading_pairs", StringComparison.CurrentCultureIgnoreCase))
                 {
                   // Ensure some values are rounded up to integers for PT comaptability 
                   newValueString = ((int)(Math.Round((oldValue + oldValueOffset), MidpointRounding.AwayFromZero) + .5)).ToString(new System.Globalization.CultureInfo("en-US"));


### PR DESCRIPTION
**Critical fix**

The changes @nnation put in for issue #72 changed all percentage offset calculations to integer regardless of the property type and therefore set all values to 0 usually. e.g.

![image](https://user-images.githubusercontent.com/34887832/53454839-72267c00-3a20-11e9-874b-b5016481606e.png)

I have adjusted the code so that if the property the percent offset is being applied to contains the word "timeout" it will use @nnation integer calculation, otherwise the original double calculation.
