### PR TITLE
Fixed issues where wrong lines were processed + minor UI fix for lists

### DIFF
--- a/Core/Helper/SystemHelper.cs
+++ b/Core/Helper/SystemHelper.cs
@@ -373,7 +373,7 @@ namespace Core.Helper
       {
         for (int i = 0; i < tokenList.Count; i++)
         {
-          result += tokenList[i].Trim() + separator;
+          result += tokenList[i].Trim() + (i < (tokenList.Count - 1) ? separator : "");
         }
 
         if (cropDoubleSeparators) result = result.Replace(separator + separator, "");

--- a/Core/Helper/SystemHelper.cs
+++ b/Core/Helper/SystemHelper.cs
@@ -637,14 +637,11 @@ namespace Core.Helper
 
       if (!property.ToString().Equals("true", StringComparison.InvariantCultureIgnoreCase) && !property.ToString().Equals("false", StringComparison.InvariantCultureIgnoreCase))
       {
-        try
-        {
-          double resultDouble = Convert.ToDouble(property);
-          result = resultDouble.ToString(new System.Globalization.CultureInfo("en-US"));
-        }
-        catch
-        {
-        }
+          double resultDouble;
+          if (double.TryParse(property.ToString(), out resultDouble))
+          {
+            result = ((decimal)resultDouble).ToString();
+          }
       }
       else
       {

--- a/Core/ProfitTrailer/SettingsFiles.cs
+++ b/Core/ProfitTrailer/SettingsFiles.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
+using System.Security.Permissions;
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -17,6 +18,27 @@ namespace Core.ProfitTrailer
 {
   public static class SettingsFiles
   {
+    private static FileSystemWatcher _presetFileWatcher;
+
+    public static FileSystemWatcher PresetFileWatcher
+    {
+      get
+      {
+        if (_presetFileWatcher == null)
+        {
+          _presetFileWatcher = new FileSystemWatcher()
+          {
+            Path = Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + Constants.PTMagicPathPresets,
+            NotifyFilter = NotifyFilters.LastWrite,
+            Filter = "",
+            IncludeSubdirectories = true
+          };
+        }
+
+        return _presetFileWatcher;
+      }
+    }
+
     public static string GetActiveSetting(PTMagicConfiguration systemConfiguration, string pairsFileName, string dcaFileName, string indicatorsFileName, LogHelper log)
     {
       string pairsPropertiesPath = systemConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + pairsFileName;
@@ -33,7 +55,6 @@ namespace Core.ProfitTrailer
         string inditactorsPropertiesPath = systemConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + indicatorsFileName;
         SettingsFiles.WriteHeaderLines(inditactorsPropertiesPath, "Default", systemConfiguration);
       }
-
 
       return result;
     }

--- a/Core/ProfitTrailer/SettingsHandler.cs
+++ b/Core/ProfitTrailer/SettingsHandler.cs
@@ -87,6 +87,8 @@ namespace Core.ProfitTrailer
             }
             break;
           default:
+            // Raw value no processing required
+            result = newValueString;
             break;
         }
       }

--- a/Core/ProfitTrailer/SettingsHandler.cs
+++ b/Core/ProfitTrailer/SettingsHandler.cs
@@ -29,7 +29,7 @@ namespace Core.ProfitTrailer
     private static string CalculatePropertyValue(string settingProperty, string oldValueString, string newValueString, out string configPropertyKey)
     {
       int valueMode = Constants.ValueModeDefault;
-      configPropertyKey = settingProperty;
+      configPropertyKey = settingProperty.Trim();
       string result = null;
 
       // Determine the mode for changing the value
@@ -339,28 +339,27 @@ namespace Core.ProfitTrailer
 
       string propertyKey;
 
+      var lineParts = line.Trim().Split("=");
+
+      string linePropertyName = lineParts[0].Trim();
       string newValueString = SystemHelper.PropertyToString(properties[settingProperty]);
-      string oldValueString = line.Substring(line.IndexOf("=") + 1).Trim();
+      string oldValueString = lineParts[1].Trim();
 
       newValueString = CalculatePropertyValue(settingProperty, oldValueString, newValueString, out propertyKey);
 
-      if (line.Contains(propertyKey, StringComparison.InvariantCultureIgnoreCase))
+      if (linePropertyName.Equals(propertyKey, StringComparison.InvariantCultureIgnoreCase))
       {
         madeSubstitutions = true;
         line = propertyKey + " = " + newValueString;
 
         string previousLine = result.Last();
-        if (previousLine.IndexOf("PTMagic Changed Line", StringComparison.InvariantCultureIgnoreCase) > -1)
+        if (previousLine.IndexOf("PTMagic changed line", StringComparison.InvariantCultureIgnoreCase) > -1)
         {
-          previousLine = "# PTMagic changed line for setting '" + settingName + "' on " + DateTime.Now.ToShortDateString() + " " + DateTime.Now.ToShortTimeString();
-
           result.RemoveAt(result.Count - 1);
-          result.Add(previousLine);
         }
         else
         {
-          string editLine = "# PTMagic changed line for setting '" + settingName + "' on " + DateTime.Now.ToShortDateString() + " " + DateTime.Now.ToShortTimeString();
-          result.Add(editLine);
+          result.Add(String.Format("# PTMagic changed {5} for setting '{0}' from value '{1}' to '{2}' on {3} {4}", settingName, oldValueString, newValueString, DateTime.Now.ToShortDateString(), DateTime.Now.ToShortTimeString(), linePropertyName));
         }
         result.Add(line);
       }

--- a/Core/ProfitTrailer/SettingsHandler.cs
+++ b/Core/ProfitTrailer/SettingsHandler.cs
@@ -140,24 +140,34 @@ namespace Core.ProfitTrailer
     {
       string result = "";
 
-      foreach (string line in ptmagicInstance.PairsLines)
+      if ((ptmagicInstance.PairsLines == null) || ptmagicInstance.PTMagicConfiguration.GeneralSettings.Application.TestMode)
       {
-        if (line.IndexOf("PTMagic_ActiveSetting", StringComparison.InvariantCultureIgnoreCase) > -1)
-        {
-          result = line.Replace("PTMagic_ActiveSetting", "", StringComparison.InvariantCultureIgnoreCase);
-          result = result.Replace("#", "");
-          result = result.Replace("=", "").Trim();
-          result = SystemHelper.StripBadCode(result, Constants.WhiteListProperties);
-          break;
-        }
+        // Return current active setting
+        result = ptmagicInstance.ActiveSetting;
       }
-
-      if (result.Equals(""))
+      else
       {
-        SettingsHandler.WriteHeaderLines("Pairs", ptmagicInstance);
-        SettingsHandler.WriteHeaderLines("DCA", ptmagicInstance);
-        SettingsHandler.WriteHeaderLines("Indicators", ptmagicInstance);
-        headerLinesAdded = true;
+        // Determine from file lines
+        foreach (string line in ptmagicInstance.PairsLines)
+        {
+          if (line.IndexOf("PTMagic_ActiveSetting", StringComparison.InvariantCultureIgnoreCase) > -1)
+          {
+            result = line.Replace("PTMagic_ActiveSetting", "", StringComparison.InvariantCultureIgnoreCase);
+            result = result.Replace("#", "");
+            result = result.Replace("=", "").Trim();
+            result = SystemHelper.StripBadCode(result, Constants.WhiteListProperties);
+            break;
+          }
+        }
+
+        if (result.Equals(""))
+        {
+          SettingsHandler.WriteHeaderLines("Pairs", ptmagicInstance);
+          SettingsHandler.WriteHeaderLines("DCA", ptmagicInstance);
+          SettingsHandler.WriteHeaderLines("Indicators", ptmagicInstance);
+          headerLinesAdded = true;
+        }
+
       }
 
       return result;


### PR DESCRIPTION
Fixed issues where:
> Lines with a substring of the intended setting got processed
> Lines that are next to a misprocessed line are deleted
> Fixed issue where rendered lists always has a trailing separator
> Fixed issue with missing values for literals

Enhancements:
> Ensured file edit comments explain what is going on
> Added fix for #55 monitoring _preset files
