### PR TITLE
Fixes for when settings have blank file properties

### DIFF
--- a/Core/DataObjects/PTMagicData.cs
+++ b/Core/DataObjects/PTMagicData.cs
@@ -40,7 +40,6 @@ namespace Core.Main.DataObjects.PTMagicData
     public string ProfitTrailerServerAPIToken { get; set; }
     public string ProfitTrailerMonitorURL { get; set; } = "http://localhost:8081/";
     public string ProfitTrailerDefaultSettingName { get; set; } = "default";
-    public bool AlwaysLoadDefaultBeforeSwitch { get; set; } = true;
     public int FloodProtectionMinutes { get; set; } = 15;
     public string Exchange { get; set; }
     public double StartBalance { get; set; } = 0;

--- a/Monitor/Pages/SettingsGeneral.cshtml
+++ b/Monitor/Pages/SettingsGeneral.cshtml
@@ -90,13 +90,6 @@
               </div>
 
               <div class="form-group row">
-                <label class="col-md-4 col-form-label">Always Load Default Before Switch <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="If this is enabled, PTMagic will always load default settings before switching to another setting."></i></label>
-                <div class="col-md-8">
-                  <input type="checkbox" name="Application_AlwaysLoadDefaultBeforeSwitch" checked="@(Model.PTMagicConfiguration.GeneralSettings.Application.AlwaysLoadDefaultBeforeSwitch)" data-plugin="switchery" data-color="#81c868" data-size="small" />
-                </div>
-              </div>
-
-              <div class="form-group row">
                 <label class="col-md-4 col-form-label">Flood Protection Minutes <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="If a price trend is just zig-zagging around its trigger, you may want to protect your settings from getting switched back and forth every minute."></i></label>
                 <div class="col-md-8">
                   <input type="text" class="form-control" name="Application_FloodProtectionMinutes" value="@Model.PTMagicConfiguration.GeneralSettings.Application.FloodProtectionMinutes.ToString()">

--- a/Monitor/Pages/SettingsGeneral.cshtml.cs
+++ b/Monitor/Pages/SettingsGeneral.cshtml.cs
@@ -70,7 +70,6 @@ namespace Monitor.Pages
       PTMagicConfiguration.GeneralSettings.Application.Exchange = HttpContext.Request.Form["Application_Exchange"];
       PTMagicConfiguration.GeneralSettings.Application.StartBalance = SystemHelper.TextToDouble(HttpContext.Request.Form["Application_StartBalance"], PTMagicConfiguration.GeneralSettings.Application.StartBalance, "en-US");
       PTMagicConfiguration.GeneralSettings.Application.TimezoneOffset = HttpContext.Request.Form["Application_TimezoneOffset"].ToString().Replace(" ", "");
-      PTMagicConfiguration.GeneralSettings.Application.AlwaysLoadDefaultBeforeSwitch = HttpContext.Request.Form["Application_AlwaysLoadDefaultBeforeSwitch"].Equals("on");
       PTMagicConfiguration.GeneralSettings.Application.FloodProtectionMinutes = SystemHelper.TextToInteger(HttpContext.Request.Form["Application_FloodProtectionMinutes"], PTMagicConfiguration.GeneralSettings.Application.FloodProtectionMinutes);
       PTMagicConfiguration.GeneralSettings.Application.InstanceName = HttpContext.Request.Form["Application_InstanceName"];
       PTMagicConfiguration.GeneralSettings.Application.CoinMarketCapAPIKey = HttpContext.Request.Form["Application_CoinMarketCapAPIKey"];

--- a/PTMagic/_defaults/_default settings PT 2.x/_default settings BTC or ETH/settings.general.json
+++ b/PTMagic/_defaults/_default settings PT 2.x/_default settings BTC or ETH/settings.general.json
@@ -12,8 +12,7 @@
       "StartBalance": 0, // The balance you had in your wallet when you started working with Profit Trailer
       "TimezoneOffset": "+0:00", // Your timezone offset from UTC time
       "MainFiatCurrency": "USD", // Your main fiat currency that will be used in the monitor
-      "AlwaysLoadDefaultBeforeSwitch": true, // If this is enabled, PTMagic will always load default settings before switching to another setting
-      "FloodProtectionMinutes": 15, // If a price trend is just zig-zagging around its trigger, you may want to protect your settings from getting switched back and forth every minute
+      "FloodProtectionMinutes": 0, // If a price trend is just zig-zagging around its trigger, you may want to protect your settings from getting switched back and forth every minute
       "InstanceName": "PT Magic", // The name of the instance of this bot. This will be used in your monitor and your Telegram messages. In case you are running more than one bot, you may set different names to separate them
       "CoinMarketCapAPIKey": "", //CoinMarketCap Api
       "FreeCurrencyConverterAPIKey": "" // If "MainFiatCurrency" above is anything other than USD, you must obtain an API key from https://free.currencyconverterapi.com/free-api-key 

--- a/PTMagic/_defaults/_default settings PT 2.x/_default settings USDT/settings.general.json
+++ b/PTMagic/_defaults/_default settings PT 2.x/_default settings USDT/settings.general.json
@@ -12,8 +12,7 @@
       "StartBalance": 0, // The balance you had in your wallet when you started working with Profit Trailer
       "TimezoneOffset": "+0:00", // Your timezone offset from UTC time
       "MainFiatCurrency": "USD", // Your main fiat currency that will be used in the monitor
-      "AlwaysLoadDefaultBeforeSwitch": true, // If this is enabled, PTMagic will always load default settings before switching to another setting
-      "FloodProtectionMinutes": 15, // If a price trend is just zig-zagging around its trigger, you may want to protect your settings from getting switched back and forth every minute
+      "FloodProtectionMinutes": 0, // If a price trend is just zig-zagging around its trigger, you may want to protect your settings from getting switched back and forth every minute
       "InstanceName": "PT Magic", // The name of the instance of this bot. This will be used in your monitor and your Telegram messages. In case you are running more than one bot, you may set different names to separate them
       "CoinMarketCapAPIKey": "", //CoinMarketCap Api
       "FreeCurrencyConverterAPIKey": "" // If "MainFiatCurrency" above is anything other than USD, you must obtain an API key from https://free.currencyconverterapi.com/free-api-key 

--- a/_Development/DevSettings/settings.general.json
+++ b/_Development/DevSettings/settings.general.json
@@ -12,8 +12,7 @@
       "StartBalance": 0, // The balance you had in your wallet when you started working with Profit Trailer
       "TimezoneOffset": "+0:00", // Your timezone offset from UTC time
       "MainFiatCurrency": "USD", // Your main fiat currency that will be used in the monitor
-      "AlwaysLoadDefaultBeforeSwitch": true, // If this is enabled, PTMagic will always load default settings before switching to another setting
-      "FloodProtectionMinutes": 15, // If a price trend is just zig-zagging around its trigger, you may want to protect your settings from getting switched back and forth every minute
+      "FloodProtectionMinutes": 0, // If a price trend is just zig-zagging around its trigger, you may want to protect your settings from getting switched back and forth every minute
       "InstanceName": "PT Magic", // The name of the instance of this bot. This will be used in your monitor and your Telegram messages. In case you are running more than one bot, you may set different names to separate them
       "CoinMarketCapAPIKey": "" //CoinMarketCap Api
     },


### PR DESCRIPTION
This fixes the issue @HojouFotytu raised when using the default settings with PTM 2.1.3
The issues stemmed from the default settings having empty empty properties sections for global settings e.g.
~~~
{
        "SettingName": "ReadyForLiftOff",
        "TriggerConnection": "AND",
        "Triggers": [
          {
            "MarketTrendName": "1h",
            "MinChange": 0.0
          },
          {
            "MarketTrendName": "12h",
            "MinChange": 0.0
          },
          {
            "MarketTrendName": "24h",
            "MaxChange": 3.0,
            "MinChange": 1.0
          }
        ],
        "PairsProperties": {
          "max_trading_pairs_OFFSET": 1,
          "DEFAULT_trailing_buy_OFFSETPERCENT": -10,
          "DEFAULT_A_sell_value_OFFSETPERCENT": 10
        },
        "DCAProperties": {
          "DEFAULT_DCA_trailing_buy_OFFSETPERCENT": -10,
          "DEFAULT_DCA_trailing_profit_OFFSETPERCENT": 10
        },
        "IndicatorsProperties": {}
      }
~~~

This caused no lines to be loaded for processing and therefore threw an exception, but the exception wasn't handled by the original code and therefore PTM got stuck flagged as in raid. I have added handling for any exceptions and ensure the raid is cancelled, so another raid attempt can occur to allow auto recovery from errors if possible.

I have refactored the code to now always load the default preset files if it cannot find a file referenced in the properties for a global setting; this didn't cause an issue previously as the config lines were always pulled from PT at the start of a raid.

The setting **AlwaysLoadDefaultBeforeSwitch** from the general settings has been removed as it serves no purpose now we don't load config lines from PT anymore.

I have also set the default settings for PTM to disable flood protection, as this should be someone elects to turn on as PTM we effectively ignore a global settings change.

I have also added a detection mechanism for Single Market Settings; PTM will now not update the PT config every raid unless the global setting has changed or the single market settings have. Much more efficient :) 

Some other cleanups and refactoring to ensure logic happens within better encapsulation.
