### PR TITLE
Ticker Changes

### DIFF
--- a/Monitor/Pages/MarketAnalyzer.cshtml
+++ b/Monitor/Pages/MarketAnalyzer.cshtml
@@ -8,6 +8,15 @@
   <link href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)assets/plugins/tablesaw/css/tablesaw.css" rel="stylesheet" type="text/css" />
   <link href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)assets/plugins/nvd3/nv.d3.min.css" rel="stylesheet" type="text/css" />
 }
+
+<div class="row">
+  <div class="col-sm-12">
+    <div class="card-box">
+    <h4 class="m-t-0 header-title text-center">Current &nbsp; @Model.Summary.MainMarket &nbsp; Price:<text class="text-autocolor">&nbsp; &nbsp; @Html.Raw(Model.MainFiatCurrencySymbol + Model.Summary.MainMarketPrice.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"))) &nbsp; </text> <small> <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="This is the value of your market currency."></i></small></h4>
+    </div>
+  </div>
+</div>
+
 <div class="row">
   <div class="col-sm-12">
     <div class="card-box">

--- a/Monitor/Pages/SalesAnalyzer.cshtml
+++ b/Monitor/Pages/SalesAnalyzer.cshtml
@@ -13,22 +13,19 @@
 }
 
 <div class="row">
- <div class="col-md-12">
-      <div class="card-box">
-        
-         @{
-           double currentBalance = Model.PTData.GetCurrentBalance();
-           string currentBalanceString = currentBalance.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US"));
-           if (currentBalance > 100) {
-             currentBalanceString = Math.Round(currentBalance, 2).ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"));
-           }
-         }
-
-         <h4 class="m-t-0 header-title text-autocolor">@Model.Summary.MainMarket &nbsp; Balance: &nbsp; &nbsp; @currentBalanceString &nbsp; &nbsp; <small> <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="This value is estimated based on your sales history and any entries on the Transactions page"></i></small></h4>
-     
-      </div>
+  <div class="col-md-12">
+    <div class="card-box">       
+      @{
+        double currentBalance = Model.PTData.GetCurrentBalance();
+        string currentBalanceString = currentBalance.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US"));
+        if (currentBalance > 100) {
+          currentBalanceString = Math.Round(currentBalance, 2).ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"));
+        }
+      }
+      <h4 class="m-t-0 header-title text-center">Total Account Value: &nbsp; &nbsp; <text class="text-autocolor"> @currentBalanceString &nbsp; @Model.Summary.MainMarket &nbsp; </text> <small> <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="This value is estimated based on your sales history and any entries on the Transactions page"></i></small></h4>
     </div>
   </div>
+</div>
 
 @if (Model.PTData.SellLog.Count == 0) {
   <div class="row">

--- a/Monitor/Pages/SalesAnalyzer.cshtml
+++ b/Monitor/Pages/SalesAnalyzer.cshtml
@@ -12,6 +12,24 @@
   <link href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)assets/plugins/datatables/buttons.bootstrap4.min.css" rel="stylesheet" type="text/css" />
 }
 
+<div class="row">
+ <div class="col-md-12">
+      <div class="card-box">
+        
+         @{
+           double currentBalance = Model.PTData.GetCurrentBalance();
+           string currentBalanceString = currentBalance.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US"));
+           if (currentBalance > 100) {
+             currentBalanceString = Math.Round(currentBalance, 2).ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"));
+           }
+         }
+
+         <h4 class="m-t-0 header-title text-autocolor">@Model.Summary.MainMarket &nbsp; Balance: &nbsp; &nbsp; @currentBalanceString &nbsp; &nbsp; <small> <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="This value is estimated based on your sales history and any entries on the Transactions page"></i></small></h4>
+     
+      </div>
+    </div>
+  </div>
+
 @if (Model.PTData.SellLog.Count == 0) {
   <div class="row">
     <div class="col-md-12">
@@ -26,7 +44,9 @@
   <div class="row">
     <div class="col-md-6">
       <div class="card-box">
+
         <h4 class="m-t-0 header-title">Sales Analysis</h4>
+        
         @{
           double totalProfit = Model.PTData.SellLog.Sum(s => s.Profit);
           double totalProfitFiat = Math.Round(totalProfit * Model.Summary.MainMarketPrice, 2);

--- a/Monitor/Pages/_Layout.cshtml
+++ b/Monitor/Pages/_Layout.cshtml
@@ -39,18 +39,10 @@
           </span>
         </div>
         <!-- End Logo container-->
-        
-        <div class="menu-extras topbar-custom">
-          <ul class="list-inline float-left mb-0">
-            <br>&nbsp;&nbsp;&nbsp;&nbsp;
-            <span class="card-box card-box-mini card-box-ptmagic-outlined" data-toggle="tooltip" data-placement="bottom" title="Active global setting">
-              <b>GS:</b> @Core.Helper.SystemHelper.SplitCamelCase(Model.Summary.CurrentGlobalSetting.SettingName)
-            </span>
-          </ul>
-        </div>
 
         <div class="menu-extras topbar-custom">
-          <ul class="list-inline float-right mb-0">
+          <ul class="list-inline float-left mb-0">
+            <li id="ticker-widgets" class="list-inline-item ticker-widgets"></li>
             <li class="menu-item list-inline-item">
               <!-- Mobile menu toggle-->
               <a class="navbar-toggle nav-link">
@@ -62,7 +54,7 @@
               </a>
               <!-- End mobile menu toggle-->
             </li>
-            <li id="ticker-widgets" class="list-inline-item ticker-widgets"></li>
+            
           </ul>
         </div>
         <!-- end menu-extras -->

--- a/Monitor/Pages/_Layout.cshtml
+++ b/Monitor/Pages/_Layout.cshtml
@@ -41,7 +41,7 @@
         <!-- End Logo container-->
 
         <div class="menu-extras topbar-custom">
-          <ul class="list-inline float-left mb-0">
+          <ul class="list-inline float-right mb-0">
             <li id="ticker-widgets" class="list-inline-item ticker-widgets"></li>
             <li class="menu-item list-inline-item">
               <!-- Mobile menu toggle-->

--- a/Monitor/Pages/_get/TickerWidgets.cshtml
+++ b/Monitor/Pages/_get/TickerWidgets.cshtml
@@ -22,25 +22,15 @@
   string iconColor = "text-success";
   string ptMagicHealthIcon = "fa-heartbeat";
   string ptMagicHealthTooltip = "PT Magic is alive and healthy!";
-  if (elapsedSecondsSinceRuntime > (intervalSeconds + intervalSeconds * 0.2)) {
+  if (elapsedSecondsSinceRuntime > (intervalSeconds + intervalSeconds * 0.5)) {
     ptMagicHealthIcon = "fa-exclamation-triangle";
     ptMagicHealthTooltip = "PT Magic seems to have problems, check the logs!";
     iconColor = "text-danger";
   }
 }
 
-@if (!Model.Summary.MainMarket.Equals("USDT", StringComparison.InvariantCultureIgnoreCase)) {
-<div class="card-box card-box-mini card-box-warning-outlined" data-toggle="tooltip" data-placement="bottom" title="Value of a single @Model.Summary.MainMarket">
-  <b>@Model.Summary.MainMarket: </b>@Html.Raw(Model.MainFiatCurrencySymbol + Model.Summary.MainMarketPrice.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")))
-</div>
-}
-
-<div class="card-box card-box-mini card-box-success-outlined" data-toggle="tooltip" data-placement="bottom" title="Approximate total value in @Model.Summary.MainMarket">
-  <b>TV:</b> @currentBalanceString @Model.Summary.MainMarket
-</div>
-
-<div class="card-box card-box-mini card-box-ptmagic-outlined" data-toggle="tooltip" data-placement="bottom" title="Active single market settings">
-  <b>SMS:</b> <a href="ManageSMS">@Html.Raw(singleSettingInfoIcon)</a> @activeSingleSettings
+<div class="card-box card-box-mini card-box-ptmagic-outlined" data-toggle="tooltip" data-placement="bottom" title="Active global setting">
+  <b>GS:</b> @Core.Helper.SystemHelper.SplitCamelCase(Model.Summary.CurrentGlobalSetting.SettingName)
 </div>
 
 <div class="card-box card-box-mini card-box-ptmagic-status-outlined @iconColor" data-toggle="tooltip" data-placement="bottom" title="@ptMagicHealthTooltip">

--- a/Monitor/Pages/_get/TickerWidgets.cshtml
+++ b/Monitor/Pages/_get/TickerWidgets.cshtml
@@ -30,11 +30,15 @@
 }
 
 <div class="card-box card-box-mini card-box-ptmagic-outlined" data-toggle="tooltip" data-placement="bottom" title="Active global setting">
-  <b>GS:</b> @Core.Helper.SystemHelper.SplitCamelCase(Model.Summary.CurrentGlobalSetting.SettingName)
+   @Core.Helper.SystemHelper.SplitCamelCase(Model.Summary.CurrentGlobalSetting.SettingName)
+</div>
+
+<div class="card-box card-box-mini card-box-ptmagic-outlined" data-toggle="tooltip" data-placement="bottom" title="Active single market settings">
+  <b>SMS:</b> <a href="ManageSMS">@Html.Raw(singleSettingInfoIcon)</a> @activeSingleSettings
 </div>
 
 <div class="card-box card-box-mini card-box-ptmagic-status-outlined @iconColor" data-toggle="tooltip" data-placement="bottom" title="@ptMagicHealthTooltip">
-  <b>PTM: </b><i class="fa @ptMagicHealthIcon @iconColor"></i>
+  <i class="fa @ptMagicHealthIcon @iconColor"></i>
 </div>
 
 <script type="text/javascript">

--- a/Monitor/wwwroot/assets/css/custom.css
+++ b/Monitor/wwwroot/assets/css/custom.css
@@ -71,12 +71,6 @@
   font-size: 0.78571rem;
 }
 
-@media only screen and (max-width: 991px) {
-  .ticker-widgets {
-    display:none;
-  }
-}
-
 .ticker-widgets div {
   display: inline-block;
   margin-top: 12px;

--- a/PTMagic/Program.cs
+++ b/PTMagic/Program.cs
@@ -7,7 +7,7 @@ using Core.Helper;
 using Core.Main.DataObjects.PTMagicData;
 using Microsoft.Extensions.DependencyInjection;
 
-[assembly: AssemblyVersion("2.1.3")]
+[assembly: AssemblyVersion("2.2.0")]
 [assembly: AssemblyProduct("PT Magic")]
 
 namespace PTMagic


### PR DESCRIPTION
Altered the top ticker for better fit/functionality on mobile devices. 
- Moved TV (Total Value) to Sales Analyzer page
- Removed price of base currency
- Removed SMS count total
- Fixed a problem that prevented the current global setting from refreshing when it changed
- Slightly increased delay time check for PTM Health to reduce the number of false alarms
- The remaining ticker boxes (Global Setting and PTM Health) remain visible on small screens.


