### PR TITLE
Possible buys update + other minor tweaks

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -7,14 +7,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NLog" Version="4.5.0-rc04" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.0.0-rtm-rc6" />
+    <PackageReference Include="NLog" Version="4.5.10" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="SharpZipLib" Version="1.0.0-alpha2" />
-    <PackageReference Include="Telegram.Bot" Version="14.0.0-rc-367" />
+    <PackageReference Include="SharpZipLib" Version="*" />
+    <PackageReference Include="Telegram.Bot" Version="*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Core/DataObjects/PTMagicData.cs
+++ b/Core/DataObjects/PTMagicData.cs
@@ -75,7 +75,7 @@ namespace Core.Main.DataObjects.PTMagicData
     public string TvStudyB { get; set; } = "";
     public string TvStudyC { get; set; } = "";
     public string TvStudyD { get; set; } = "";
-    
+
     public string RootUrl
     {
       get
@@ -538,6 +538,8 @@ namespace Core.Main.DataObjects.PTMagicData
     public double BBTrigger { get; set; }
     public bool IsTrailing { get; set; }
     public bool IsTrue { get; set; }
+    public bool IsSom { get; set; }
+    public int TrueStrategyCount { get; set; }
     public string Market { get; set; }
     public double ProfitPercent { get; set; }
     public double CurrentPrice { get; set; }

--- a/Core/DataObjects/ProfitTrailerData.cs
+++ b/Core/DataObjects/ProfitTrailerData.cs
@@ -350,7 +350,7 @@ namespace Core.Main.DataObjects
     {
       foreach (buyLogData rbld in rawBuyLogData)
       {
-        BuyLogData buyLogData = new BuyLogData();
+        BuyLogData buyLogData = new BuyLogData() {IsTrailing = false, IsTrue = false, IsSom = false, TrueStrategyCount = 0};
         buyLogData.Market = rbld.market;
         buyLogData.ProfitPercent = rbld.profit;
         buyLogData.TriggerValue = rbld.triggerValue;
@@ -387,6 +387,17 @@ namespace Core.Main.DataObjects
               buyStrategy.IsTrailing = bs.positive.IndexOf("trailing", StringComparison.InvariantCultureIgnoreCase) > -1;
               buyStrategy.IsTrue = bs.positive.IndexOf("true", StringComparison.InvariantCultureIgnoreCase) > -1;
 
+              // Is SOM?
+              buyLogData.IsSom = buyLogData.IsSom || buyStrategy.Name.Equals("som enabled", StringComparison.OrdinalIgnoreCase);
+
+              // Is the pair trailing?
+              buyLogData.IsTrailing = buyLogData.IsTrailing || buyStrategy.IsTrailing;
+              buyLogData.IsTrue = buyLogData.IsTrue || buyStrategy.IsTrue;
+
+              // True status strategy count total
+              buyLogData.TrueStrategyCount += buyStrategy.IsTrue ? 1 : 0;
+
+              // Add
               buyLogData.BuyStrategies.Add(buyStrategy);
             }
           }

--- a/Monitor/Pages/_get/BuyList.cshtml
+++ b/Monitor/Pages/_get/BuyList.cshtml
@@ -41,7 +41,7 @@
     } else {
       <th class="align-top"><a href="@Core.Helper.SystemHelper.GetMarketLink(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform,Model.PTMagicConfiguration.GeneralSettings.Application.Exchange, buyLogEntry.Market, Model.Summary.MainMarket)" target="_blank">@buyLogEntry.Market</a> <i class="fa fa-exclamation-triangle text-highlight" data-toggle="tooltip" data-placement="top" data-html="true" title="@await Component.InvokeAsync("PairIcon", mps)" data-template="<div class='tooltip' role='tooltip'><div class='tooltip-arrow'></div><div class='tooltip-inner pair-tooltip'></div></div>"></i></th>
     }
-    <td class="text-autocolor">@buyLogEntry.PercChange.ToString("#,#0.00")</td>
+    <td class="text-autocolor">@buyLogEntry.PercChange.ToString("#,#0.00")%</td>
     @if (buyDisabled) {
       <td>@Html.Raw(buyStrategyText)</td>
     } else {

--- a/Monitor/Pages/_get/DashboardTop.cshtml
+++ b/Monitor/Pages/_get/DashboardTop.cshtml
@@ -23,7 +23,13 @@
             </tr>
           </thead>
           <tbody>
-            @foreach (Core.Main.DataObjects.PTMagicData.BuyLogData buyLogEntry in Model.PTData.BuyLog.OrderByDescending(b => b.IsTrailing).ThenBy(b => b.CurrentValue).Take(Model.PTMagicConfiguration.GeneralSettings.Monitor.MaxDashboardBuyEntries)) {
+            @foreach (Core.Main.DataObjects.PTMagicData.BuyLogData buyLogEntry in Model.PTData.BuyLog.OrderByDescending(b => b.IsTrailing).
+                        ThenByDescending(b => b.IsTrue).
+                        ThenByDescending(b => b.TrueStrategyCount).
+                        ThenBy(b => b.IsSom).
+                        ThenByDescending(b => b.PercChange).
+                        Take(Model.PTMagicConfiguration.GeneralSettings.Monitor.MaxDashboardBuyEntries)) {
+                          
               Core.Main.DataObjects.PTMagicData.MarketPairSummary mps = null;
               if (Model.Summary.MarketSummary.ContainsKey(buyLogEntry.Market)) {
                 mps = Model.Summary.MarketSummary[buyLogEntry.Market];
@@ -53,7 +59,7 @@
                 } else {
                   <th class="align-top"><a href="@Core.Helper.SystemHelper.GetMarketLink(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform,Model.PTMagicConfiguration.GeneralSettings.Application.Exchange, buyLogEntry.Market, Model.Summary.MainMarket)" target="_blank">@buyLogEntry.Market</a> <i class="fa fa-exclamation-triangle text-highlight" data-toggle="tooltip" data-placement="top" data-html="true" title="@await Component.InvokeAsync("PairIcon", mps)" data-template="<div class='tooltip' role='tooltip'><div class='tooltip-arrow'></div><div class='tooltip-inner pair-tooltip'></div></div>"></i></th>
                 }
-                <td class="text-autocolor">@buyLogEntry.PercChange.ToString("#,#0.00")</td>
+                <td class="text-autocolor">@buyLogEntry.PercChange.ToString("#,#0.00")%</td>
                 @if (buyDisabled) {
                   <td>@Html.Raw(buyStrategyText)</td>
                 } else {

--- a/PTMagic/PTMagic.csproj
+++ b/PTMagic/PTMagic.csproj
@@ -12,17 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="NLog" Version="4.5.11" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
     <None Include="nlog.config" CopyToOutputDirectory="Always" />
     <None Include="settings.general.json" CopyToOutputDirectory="Always" />


### PR DESCRIPTION
Possible buys now orders buy:
> Trailing pairs
> True strategy pairs
> Number of true strategies descending
> SOM pairs
> 24hr percentage change

This gives the most useful to 10 pairs.

Also updated and cleaned up the Nuget references as we were using release candidate versions of Nlog and Telegram :0

Added % to the new 24h change column