### PR TITLE
Updated to use PT data for balance and buy order tweak

### DIFF
--- a/Core/DataObjects/PTMagicData.cs
+++ b/Core/DataObjects/PTMagicData.cs
@@ -400,26 +400,6 @@ namespace Core.Main.DataObjects.PTMagicData
 
   #region Profit Trailer JSON Objects
 
-  public class PTData
-  {
-    public List<sellLogData> SellLogData { get; set; } = new List<sellLogData>();
-    public List<dcaLogData> DCALogData { get; set; } = new List<dcaLogData>();
-    public List<dcaLogData> GainLogData { get; set; } = new List<dcaLogData>();
-    public List<buyLogData> bbBuyLogData { get; set; } = new List<buyLogData>();
-  }
-
-  public class sellLogData
-  {
-    public double soldAmount { get; set; }
-    public double soldDate { get; set; }
-    public int boughtTimes { get; set; }
-    public string market { get; set; }
-    public double profit { get; set; }
-    public double avgPrice { get; set; }
-    public double currentPrice { get; set; }
-    public double fee { get; set; }
-  }
-
   public class SellLogData
   {
     public double SoldAmount { get; set; }
@@ -434,13 +414,6 @@ namespace Core.Main.DataObjects.PTMagicData
     public double SoldValue { get; set; }
   }
 
-  public class AverageCalculator
-  {
-    public double totalAmountWithSold { get; set; }
-    public double avgCost { get; set; }
-    public double totalWeightedPrice { get; set; }
-  }
-
   public class PTStrategy
   {
     public string type { get; set; }
@@ -452,29 +425,6 @@ namespace Core.Main.DataObjects.PTMagicData
     public double currentValuePercentage { get; set; }
     public int decimals { get; set; }
     public string positive { get; set; }
-  }
-
-  public class dcaLogData
-  {
-    public int boughtTimes { get; set; } = 0;
-    public string market { get; set; }
-    public string positive { get; set; }
-    public double buyProfit { get; set; }
-    public double BBLow { get; set; }
-    public double BBTrigger { get; set; }
-    public double highbb { get; set; }
-    public double profit { get; set; }
-    public double avgPrice { get; set; }
-    public double totalCost { get; set; }
-    public double totalAmount { get; set; }
-    public int firstBoughtDate { get; set; }
-    public double currentPrice { get; set; }
-    public string sellStrategy { get; set; }
-    public string buyStrategy { get; set; }
-    public double triggerValue { get; set; }
-    public double percChange { get; set; }
-    public List<PTStrategy> buyStrategies { get; set; }
-    public List<PTStrategy> sellStrategies { get; set; }
   }
 
   public class Strategy
@@ -504,6 +454,7 @@ namespace Core.Main.DataObjects.PTMagicData
     public double ProfitPercent { get; set; }
     public double AverageBuyPrice { get; set; }
     public double TotalCost { get; set; }
+    public double CurrentValue { get; set; }
     public double Amount { get; set; }
     public double CurrentPrice { get; set; }
     public double SellTrigger { get; set; }
@@ -515,27 +466,14 @@ namespace Core.Main.DataObjects.PTMagicData
     public List<Strategy> SellStrategies { get; set; } = new List<Strategy>();
   }
 
-  public class buyLogData
-  {
-    public string market { get; set; }
-    public string positive { get; set; }
-    public double BBLow { get; set; }
-    public double BBHigh { get; set; }
-    public double BBTrigger { get; set; }
-    public double profit { get; set; }
-    public double currentPrice { get; set; }
-    public double currentValue { get; set; }
-    public string buyStrategy { get; set; }
-    public double triggerValue { get; set; }
-    public double percChange { get; set; }
-    public List<PTStrategy> buyStrategies { get; set; }
-  }
-
   public class BuyLogData
   {
     public double CurrentLowBBValue { get; set; }
     public double CurrentHighBBValue { get; set; }
     public double BBTrigger { get; set; }
+    public double CurrentValue { get; set; }
+    public double TriggerValue { get; set; }
+    public string BuyStrategy { get; set; }
     public bool IsTrailing { get; set; }
     public bool IsTrue { get; set; }
     public bool IsSom { get; set; }
@@ -543,12 +481,20 @@ namespace Core.Main.DataObjects.PTMagicData
     public string Market { get; set; }
     public double ProfitPercent { get; set; }
     public double CurrentPrice { get; set; }
-    public double CurrentValue { get; set; }
-    public double TriggerValue { get; set; }
+    public int BoughtTimes { get; set; }
     public double PercChange { get; set; }
-    public string BuyStrategy { get; set; }
     public List<Strategy> BuyStrategies { get; set; } = new List<Strategy>();
   }
 
+  public class SummaryData
+  {
+    public double Balance { get; set; }
+    public double StartBalance { get; set; }
+    public double PairsValue { get; set; }
+    public double DCAValue { get; set; }
+    public double PendingValue { get; set; }
+    public double DustValue { get; set; }
+    public string Market { get; set; }
+  }
   #endregion
 }

--- a/Monitor/Pages/SalesAnalyzer.cshtml
+++ b/Monitor/Pages/SalesAnalyzer.cshtml
@@ -27,8 +27,8 @@
                   currentBalanceString = Math.Round(currentBalance, 2).ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"));
                 }
               }
-              <th class="text-left">Estimated Account Value: &nbsp; &nbsp; <text class="text-autocolor"> @currentBalanceString &nbsp; @Model.Summary.MainMarket &nbsp; </text> <small> <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="This is based on your sales history and entries on the Transactions page.  It doesn't include any currently held positions."></i></small></th>
-              <th class="text-right">Starting Account Value: &nbsp; &nbsp; <text class="text-autocolor"> @Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance &nbsp; @Model.Summary.MainMarket &nbsp; </text> <small> <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="This is the starting vlaue found in your settings file"></i></small></th>
+              <th class="text-left">Estimated Account Value: &nbsp; &nbsp; <text class="text-autocolor"> @currentBalanceString &nbsp; @Model.Summary.MainMarket &nbsp; </text> <small> <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="This is based on your sales history, entries on the Transactions page and any currently held positions."></i></small></th>
+              <th class="text-right">Starting Account Value: &nbsp; &nbsp; <text class="text-autocolor"> @Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance &nbsp; @Model.Summary.MainMarket &nbsp; </text> <small> <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="This is the starting value found in your settings file"></i></small></th>
             </tr>
           </thead>
         </table>

--- a/Monitor/Pages/_get/DashboardTop.cshtml
+++ b/Monitor/Pages/_get/DashboardTop.cshtml
@@ -23,10 +23,11 @@
             </tr>
           </thead>
           <tbody>
-            @foreach (Core.Main.DataObjects.PTMagicData.BuyLogData buyLogEntry in Model.PTData.BuyLog.OrderByDescending(b => b.IsTrailing).
+            @foreach (Core.Main.DataObjects.PTMagicData.BuyLogData buyLogEntry in Model.PTData.BuyLog.OrderBy(b => b.IsSom).
+                        ThenByDescending(b => b.IsTrailing).
                         ThenByDescending(b => b.IsTrue).
                         ThenByDescending(b => b.TrueStrategyCount).
-                        ThenBy(b => b.IsSom).
+                        
                         ThenByDescending(b => b.PercChange).
                         Take(Model.PTMagicConfiguration.GeneralSettings.Monitor.MaxDashboardBuyEntries)) {
                           


### PR DESCRIPTION
- Changed PTM to use dynamic objects when loading PT data
- Current balance now uses the values from PT directly
- Tweaked possible buy sorting to ensure SOM pairs go to the bottom