### PR TITLE
Excessive Requests

### DIFF
--- a/Core/ProfitTrailer/StrategyHelper.cs
+++ b/Core/ProfitTrailer/StrategyHelper.cs
@@ -375,6 +375,12 @@ namespace Core.ProfitTrailer
         case "buy value below dust":
           result = String.Concat(strategyLetter, "DUST");
           break;
+        case "sell wall detected":
+          result = String.Concat(strategyLetter, "WALL");
+          break;
+        case "ignoring buy trigger":
+          result = String.Concat(strategyLetter, "TRIG");
+          break;
         default:
           break;
       }

--- a/Monitor/Pages/_get/DashboardTop.cshtml
+++ b/Monitor/Pages/_get/DashboardTop.cshtml
@@ -96,7 +96,7 @@
               <tr>
                 <th>Market</th>             
                 <th class="text-left" data-toggle="tooltip" data-placement="top" title="Market trend last 24 hours">24H Trend</th>
-                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Total Bag Value">Value</th>
+                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Buy Value">Value</th>
                 <th></th>
                 <th class="text-left" data-toggle="tooltip" data-placement="top" title="Active buy strategies">DCA Buy Strats</th>
                 <th class="text-left" data-toggle="tooltip" data-placement="top" title="Active sell strategies">Sell Strats</th>

--- a/Monitor/Pages/_get/DashboardTop.cshtml
+++ b/Monitor/Pages/_get/DashboardTop.cshtml
@@ -96,7 +96,7 @@
               <tr>
                 <th>Market</th>             
                 <th class="text-left" data-toggle="tooltip" data-placement="top" title="Market trend last 24 hours">24H Trend</th>
-                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Buy Value">Value</th>
+                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Total Buy Value">Value</th>
                 <th></th>
                 <th class="text-left" data-toggle="tooltip" data-placement="top" title="Active buy strategies">DCA Buy Strats</th>
                 <th class="text-left" data-toggle="tooltip" data-placement="top" title="Active sell strategies">Sell Strats</th>


### PR DESCRIPTION
- Fixes a problem where large values for StoreDataMaxHours causes PTM to exceed allowed binance requests per minute when gathering historical market data on the initial run.  #143 

- Added a shortcut for PT information "Sell Wall Detected" -> "WALL"
- Added a shortcut for PT information "Ignoring Buy Trigger" -> "TRIG"
- Changed tooltip for "Value" in pairs list to "Total Buy Value"