### PR TITLE
DCA Calculator Bugfix

### DIFF
--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -2313,10 +2313,26 @@ namespace Core.Main
 
       this.LastRuntimeSummary.DCATrigger = dcaDefaultTrigger;
 
+
+      // Get PROFITPERCENTAGE strategy label
+      string ProfitPercentageLabel = "";
+      for (char c = 'A'; c <= 'Z'; c++)
+      {
+        
+        string buyStrategyName = SettingsHandler.GetCurrentPropertyValue(dcaProperties, "DEFAULT_DCA_" + c + "_buy_strategy", "");
+        if (buyStrategyName.Contains("PROFITPERCENTAGE"))
+        {
+          
+          ProfitPercentageLabel = "" + c;
+        }
+      }
+
+      this.Log.DoLogInfo("DCA ProfitPercentage Label:" + ProfitPercentageLabel);
+
       // Get configured DCA triggers
       for (int dca = 1; dca <= maxDCALevel; dca++)
       {
-        string dcaTriggerString = SettingsHandler.GetCurrentPropertyValue(dcaProperties, "buy_trigger_" + dca.ToString(), "DEFAULT_DCA_buy_trigger_" + dca.ToString());
+        string dcaTriggerString = SettingsHandler.GetCurrentPropertyValue(dcaProperties, ProfitPercentageLabel + "buy_value_" + dca.ToString(), "DEFAULT_DCA_" + ProfitPercentageLabel + "_buy_value_" + dca.ToString());
         if (!String.IsNullOrEmpty(dcaTriggerString))
         {
           double dcaTrigger = SystemHelper.TextToDouble(dcaTriggerString, 0, "en-US");

--- a/Core/ProfitTrailer/StrategyHelper.cs
+++ b/Core/ProfitTrailer/StrategyHelper.cs
@@ -336,6 +336,45 @@ namespace Core.ProfitTrailer
         case "anderson":
           result = String.Concat(strategyLetter, "AND");
           break;
+        case "pdlow":
+          result = String.Concat(strategyLetter, "PDL");
+          break;
+        case "pdclose":
+          result = String.Concat(strategyLetter, "PDC");
+          break;
+        case "signal":
+          result = String.Concat(strategyLetter, "SIG");
+          break;
+        case "changepercentage":
+          result = String.Concat(strategyLetter, "CHGPCT");
+          break;
+        case "profitpercentage":
+          result = String.Concat(strategyLetter, "PPCT");
+          break;
+        case "lastdcabuy":
+          result = String.Concat(strategyLetter, "LASTDCA");
+          break;
+        case "fixedprice":
+          result = String.Concat(strategyLetter, "FIXED");
+          break;
+        case "lowatrband":
+          result = String.Concat(strategyLetter, "LATR");
+          break;
+        case "highatrband":
+          result = String.Concat(strategyLetter, "HATR");
+          break;
+        case "atrpercentage":
+          result = String.Concat(strategyLetter, "ATRPCT");
+          break;
+        case "vwappercentage":
+          result = String.Concat(strategyLetter, "VWAP");
+          break;
+        case "mvwappercentage":
+          result = String.Concat(strategyLetter, "MVWAP");
+          break;
+        case "btcdominance":
+          result = String.Concat(strategyLetter, "BTCDOM");
+          break;
         case "config som enabled":
           result = String.Concat(strategyLetter, "SOM");
           break;
@@ -445,7 +484,19 @@ namespace Core.ProfitTrailer
           case "dema":
           case "hma":
           case "pdhigh":
+          case "pdlow":
+          case "pdclose":
           case "signal":
+          case "changepercentage":
+          case "profitpercentage":
+          case "lastdcabuy":
+          case "fixedprice":
+          case "lowatrband":
+          case "highatrband":
+          case "atrpercentage":
+          case "vwappercentage":
+          case "mvwappercentage":
+          case "btcdominance":
             result = true;
             break;
           default:

--- a/Monitor/Pages/DCACalculator.cshtml
+++ b/Monitor/Pages/DCACalculator.cshtml
@@ -18,7 +18,7 @@
       <h4 class="m-t-0 header-title">DCA Calculator</h4>
 
       <p class="m-b-20">
-        Use this calculator to help building a proper setup for your Profit Trailer settings for <b>ALL_max_trading_pairs</b>, <b>ALL_@maxCostCaption.ToLower()_cost</b> and <b>DCA levels</b>.<br />
+        Use this calculator to help build a proper setup for your Profit Trailer settings for <b>DEFAULT_max_trading_pairs</b>, <b>DEFAULT_@maxCostCaption.ToLower()_cost</b> and <b>DCA PROFITPERCENTAGE buy levels</b>.<br />
         To do so enter your available balance and adjust the values to whatever you consider the best setting for your parameters.<br />
         If you are having problems understanding the different modes, <a href="https://github.com/PTMagicians/PTMagic/wiki/DCA-Calculator" target="_blank">please read this wiki article</a>.
       </p>
@@ -39,7 +39,7 @@
           In <i>simple mode</i> the DCA calculator will only take your number of pairs, DCA levels and initial cost and will calculate the necessary fundings for you. In this mode the ANDERSON method is quite inaccurate as it will calculate the DCA steps by <b>using the the simple proportional cost</b> for each DCA level, regardless of what level the price may be at the time the DCA buy will happen.
         </div>
         <div class="col-md-6">
-          In <i>advanced mode</i> the DCA calculator will also take your DCA triggers into account for the calculation of the necessary fundings for you. In this mode the ANDERSON method is being calculated more accurate as it will calculate the necessary costs using your buy triggers to calculate the actual <b>cost of coins at the current price</b> according to your triggers and percentages.
+          In <i>advanced mode</i> the DCA calculator will also take your DCA PROFITPERCENTAGE buy levels into account for the calculation of the necessary fundings for you. In this mode the ANDERSON method is being calculated more accurate as it will calculate the necessary costs using your buy levels to calculate the actual <b>cost of coins at the current price</b> according to your triggers and percentages.
         </div>
       </div>
     </div>

--- a/PTMagic/Program.cs
+++ b/PTMagic/Program.cs
@@ -7,7 +7,7 @@ using Core.Helper;
 using Core.Main.DataObjects.PTMagicData;
 using Microsoft.Extensions.DependencyInjection;
 
-[assembly: AssemblyVersion("2.2.8")]
+[assembly: AssemblyVersion("2.2.9")]
 [assembly: AssemblyProduct("PT Magic")]
 
 namespace PTMagic


### PR DESCRIPTION
- Fixed DCA Calculator page freezing when no buy triggers found in the DCA.properties file. DCA_buy_triggers were deprecated in PT 2.4.2, replaced with the strategy PROFITPERCENTAGE. PTM now only uses PROFITPERCENTAGE in the DCA calculator.  See #158 

- Added new strategy shortcuts: changepercentage, pdlow, pdclose, lastdcabuy, fixedprice, lowatrband, highatrband, atrpercentage, profitpercentage, vwappercentage, mvwappercentage, btcdominance