### PR TITLE
Analyzer Settings GUI fix

### DIFF
--- a/Core/ProfitTrailer/StrategyHelper.cs
+++ b/Core/ProfitTrailer/StrategyHelper.cs
@@ -421,7 +421,7 @@ namespace Core.ProfitTrailer
           result = String.Concat(strategyLetter, "TRIG");
           break;
         case "no dca buy logic":
-          result = String.Concat(strategyLetter, "NO DCA");
+          result = String.Concat(strategyLetter, "NODCA");
           break;
         default:
           break;

--- a/Core/ProfitTrailer/StrategyHelper.cs
+++ b/Core/ProfitTrailer/StrategyHelper.cs
@@ -420,6 +420,9 @@ namespace Core.ProfitTrailer
         case "ignoring buy trigger":
           result = String.Concat(strategyLetter, "TRIG");
           break;
+        case "no dca buy logic":
+          result = String.Concat(strategyLetter, "NO DCA");
+          break;
         default:
           break;
       }

--- a/Monitor/Pages/SettingsAnalyzer.cshtml
+++ b/Monitor/Pages/SettingsAnalyzer.cshtml
@@ -13,17 +13,17 @@
       <h4 class="m-t-0 header-title">Analyzer Settings<span></span></h4>
 
       <p>
-        In this area you may change the settings of your <b>settings.analyzer.json</b> file. Please use this with caution as all settings you saved here will directly affect your PT Magic bot.
+        In this area you may change the settings of your <b>settings.analyzer.json</b> file. <br>Please use this with caution as all settings you saved here will directly affect your PT Magic bot.
       </p>
-      <p class="text-danger">Please note: When you save your settings using this interface, all existing comments will be removed from your settings.analyzer.json!</p>
+      <p class="text-danger">NOTICE: When you save your settings using this interface, any existing comments will be removed from your settings.analyzer.json!</p>
     </div>
   </div>
 </div>
 
 <div class="row">
-  <div class="col-md-4">
+  <div class="col-md-6">
     <div class="card-box">
-      <h4 class="m-t-0 header-title">Restore Backup <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="PT Magic automatically creates a backup when you save your settings.analyzer.json file using this interface. In case you notice some suspicious behaviour or just want to go back to your previous settings, you may restore the most recent backup here."></i></h4>
+      <h4 class="m-t-0 header-title">Restore Backup <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="PT Magic automatically creates a backup when you save your settings.analyzer.json file using this interface. If you want to go back to your previous settings, you may restore your previous settings."></i></h4>
 
       <p>
         You messed up your settings?<br />Restore your backup!
@@ -34,7 +34,7 @@
       </button>
     </div>
   </div>
-  <div class="col-md-4">
+  <div class="col-md-6">
     <div class="card-box">
       <h4 class="m-t-0 header-title">Download Settings</h4>
 
@@ -47,19 +47,7 @@
       </a>
     </div>
   </div>
-  <div class="col-md-4">
-    <div class="card-box">
-      <h4 class="m-t-0 header-title">Upload Settings</h4>
-
-      <p>
-        Found some settings somewhere?<br />Upload them!
-      </p>
-
-      <button class="btn btn-ptmagic btn-custom text-uppercase waves-effect waves-light">
-        Coming soon...
-      </button>
-    </div>
-  </div>
+  
 </div>
 
 <div class="row">
@@ -67,7 +55,8 @@
     <div class="card-box">
       <div class="row">
         <div class="col-md-4">
-          <h4 class="m-t-0 header-title">Market Trends (@Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.MarketTrends.Count)</h4>
+          <h4 class="m-t-0 header-title">Market Trends (@Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.MarketTrends.Count) <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Click a trend to jump to it on the page.  Press HOME on your keyboard to return to this list."></i></h4>
+
           <ul>
             @foreach (Core.Main.DataObjects.PTMagicData.MarketTrend mt in Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.MarketTrends) {
               <li><a href="#MarketTrend_@Core.Helper.SystemHelper.StripBadCode(mt.Name, Core.Main.Constants.WhiteListNames)">@Core.Helper.SystemHelper.SplitCamelCase(mt.Name)</a></li>
@@ -75,7 +64,7 @@
           </ul>
         </div>
         <div class="col-md-4">
-          <h4 class="m-t-0 header-title">Global Settings (@Model.PTMagicConfiguration.AnalyzerSettings.GlobalSettings.Count)</h4>
+          <h4 class="m-t-0 header-title">Global Settings (@Model.PTMagicConfiguration.AnalyzerSettings.GlobalSettings.Count) <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Click a setting to jump to it on the page.  Press HOME on your keyboard to return to this list."></i></h4>
 
           <ul>
             @foreach (Core.Main.DataObjects.PTMagicData.GlobalSetting gs in Model.PTMagicConfiguration.AnalyzerSettings.GlobalSettings) {
@@ -84,7 +73,7 @@
           </ul>
         </div>
         <div class="col-md-4">
-          <h4 class="m-t-0 header-title">Single Market Settings (@Model.PTMagicConfiguration.AnalyzerSettings.SingleMarketSettings.Count)</h4>
+          <h4 class="m-t-0 header-title">Single Market Settings (@Model.PTMagicConfiguration.AnalyzerSettings.SingleMarketSettings.Count) <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Click a setting to jump to it on the page.  Press HOME on your keyboard to return to this list."></i></h4>
 
           <ul>
             @foreach (Core.Main.DataObjects.PTMagicData.SingleMarketSetting sms in Model.PTMagicConfiguration.AnalyzerSettings.SingleMarketSettings) {
@@ -101,14 +90,32 @@
           </button>
         </div>
         <div class="col-md-4">
-          <button class="btn btn-ptmagic btn-custom  btn-block text-uppercase waves-effect waves-light btn-new" data-datatype="GlobalSetting">
-            Add Global Setting
-          </button>
+          <div class="btn-group btn-block">
+            <button class="btn btn-ptmagic btn-custom  btn-block text-uppercase waves-effect waves-light dropdown-toggle" data-toggle="dropdown">
+              Add Global Setting
+            </button>
+            <div class="dropdown-menu">
+              @foreach (Core.Main.DataObjects.PTMagicData.GlobalSetting gs in Model.PTMagicConfiguration.AnalyzerSettings.GlobalSettings) {
+                <a class="dropdown-item btn-new" data-datatype="GlobalSetting" data-datatarget="@Core.Helper.SystemHelper.StripBadCode(gs.SettingName, Core.Main.Constants.WhiteListNames)">Add before <i>@Core.Helper.SystemHelper.SplitCamelCase(gs.SettingName)</i></a>
+              }
+            </div>
+          </div>
         </div>
         <div class="col-md-4">
-          <button class="btn btn-ptmagic btn-custom  btn-block text-uppercase waves-effect waves-light btn-new" data-datatype="SingleMarketSetting">
-            Add Single Market Setting
-          </button>
+          <div class="btn-group btn-block">
+            <button class="btn btn-ptmagic btn-custom  btn-block text-uppercase waves-effect waves-light dropdown-toggle" data-toggle="dropdown">
+              Add Single Market Setting
+            </button>
+            <div class="dropdown-menu">
+              @foreach (Core.Main.DataObjects.PTMagicData.SingleMarketSetting sms in Model.PTMagicConfiguration.AnalyzerSettings.SingleMarketSettings) {
+                <a class="dropdown-item btn-new" data-datatype="SingleMarketSetting" data-datadirection="before" data-datatarget="@Core.Helper.SystemHelper.StripBadCode(sms.SettingName, Core.Main.Constants.WhiteListNames)">Add before <i>@Core.Helper.SystemHelper.SplitCamelCase(sms.SettingName)</i></a>
+              }
+              <div class="dropdown-divider"></div>
+              @foreach (Core.Main.DataObjects.PTMagicData.SingleMarketSetting sms in Model.PTMagicConfiguration.AnalyzerSettings.SingleMarketSettings) {
+                <a class="dropdown-item btn-new" data-datatype="SingleMarketSetting" data-datadirection="after" data-datatarget="@Core.Helper.SystemHelper.StripBadCode(sms.SettingName, Core.Main.Constants.WhiteListNames)">Add after <i>@Core.Helper.SystemHelper.SplitCamelCase(sms.SettingName)</i></a>
+              }
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -119,33 +126,26 @@
   <div class="row">
     <div class="col-md-12">
       <div class="card-box">
-        <div class="panel-group" style="">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h3 class="panel-title"><strong><a href="#collapse0" data-toggle="collapse">MARKET ANALYZER</a></strong></h3>
-            </div>
-            <div id="collapse0" class="panel-collapse collapse">
-              <div class="form-group row">
-                <label class="col-md-4 col-form-label">Store Data Max Hours <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Number of hours to store market data."></i></label>
-                <div class="col-md-8">
-                  <input type="text" class="form-control" name="MarketAnalyzer_StoreDataMaxHours" value="@Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours.ToString()">
-                </div>
-              </div>
+        <h4 class="m-t-0 header-title">Market Analyzer</h4>
 
-              <div class="form-group row">
-                <label class="col-md-4 col-form-label">Interval Minutes <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Interval in minutes for PTMagic to check market trends and triggers."></i></label>
-                <div class="col-md-8">
-                  <input type="text" class="form-control" name="MarketAnalyzer_IntervalMinutes" value="@Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes.ToString()">
-                </div>
-              </div>
+        <div class="form-group row">
+          <label class="col-md-4 col-form-label">Store Data Max Hours <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Number of hours to store market data."></i></label>
+          <div class="col-md-8">
+            <input type="text" class="form-control" name="MarketAnalyzer_StoreDataMaxHours" value="@Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours.ToString()">
+          </div>
+        </div>
 
-              <div class="form-group row">
-                <label class="col-md-4 col-form-label">Exclude Main Currency <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Excludes the main currency (for example BTC) from market trend analysis."></i></label>
-                <div class="col-md-8">
-                  <input type="checkbox" name="MarketAnalyzer_ExcludeMainCurrency" checked="@(Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.ExcludeMainCurrency)" data-plugin="switchery" data-color="#81c868" data-size="small" />
-                </div>
-              </div>
-            </div>
+        <div class="form-group row">
+          <label class="col-md-4 col-form-label">Interval Minutes <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Interval in minutes for PTMagic to check market trends and triggers."></i></label>
+          <div class="col-md-8">
+            <input type="text" class="form-control" name="MarketAnalyzer_IntervalMinutes" value="@Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes.ToString()">
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <label class="col-md-4 col-form-label">Exclude Main Currency <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Excludes the main currency (for example BTC) from market trend analysis."></i></label>
+          <div class="col-md-8">
+            <input type="checkbox" name="MarketAnalyzer_ExcludeMainCurrency" checked="@(Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.ExcludeMainCurrency)" data-plugin="switchery" data-color="#81c868" data-size="small" />
           </div>
         </div>
       </div>
@@ -155,22 +155,7 @@
   <div id="MarketAnalyzer_MarketTrends">
     @if (Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.MarketTrends.Count > 0) {
       @foreach (Core.Main.DataObjects.PTMagicData.MarketTrend mt in Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.MarketTrends) {
-        <div class="row">
-          <div class="col-md-12">
-            <div class="card-box">
-              <div class="panel-group" style="">
-                <div class="panel panel-default">
-                  <div class="panel-heading">
-                    <h3 class="panel-title"><strong><a href="#@Core.Helper.SystemHelper.StripBadCode(mt.Name, Core.Main.Constants.WhiteListNames)" data-toggle="collapse">MARKET TREND: @Core.Helper.SystemHelper.StripBadCode(mt.Name, Core.Main.Constants.WhiteListNames)</a></strong></h3>
-                  </div>
-                  <div id="@Core.Helper.SystemHelper.StripBadCode(mt.Name, Core.Main.Constants.WhiteListNames)" class="panel-collapse collapse">
-                    <div class="settings-markettrend" data-trendname="@Core.Helper.SystemHelper.StripBadCode(mt.Name, Core.Main.Constants.WhiteListNames)" data-rooturl="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)"><i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-           </div>
-        </div>
+        <div class="settings-markettrend" data-trendname="@Core.Helper.SystemHelper.StripBadCode(mt.Name, Core.Main.Constants.WhiteListNames)" data-rooturl="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)"><i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i></div>
       }
     } else {
       <div class="row">
@@ -186,22 +171,7 @@
   <div id="MarketAnalyzer_GlobalSettings">
     @if (Model.PTMagicConfiguration.AnalyzerSettings.GlobalSettings.Count > 0) {
       @foreach (Core.Main.DataObjects.PTMagicData.GlobalSetting gs in Model.PTMagicConfiguration.AnalyzerSettings.GlobalSettings) {
-        <div class="row">
-          <div class="col-md-12">
-            <div class="card-box">
-              <div class="panel-group" style="">
-                <div class="panel panel-default">
-                  <div class="panel-heading">
-                    <h3 class="panel-title"><strong><a href="#@Core.Helper.SystemHelper.StripBadCode(gs.SettingName, Core.Main.Constants.WhiteListNames)" data-toggle="collapse">GLOBAL SETTING: @Core.Helper.SystemHelper.StripBadCode(gs.SettingName, Core.Main.Constants.WhiteListNames)</a></strong></h3>
-                  </div>
-                  <div id="@Core.Helper.SystemHelper.StripBadCode(gs.SettingName, Core.Main.Constants.WhiteListNames)" class="panel-collapse collapse">
-                    <div class="settings-globalsetting" data-settingname="@Core.Helper.SystemHelper.StripBadCode(gs.SettingName, Core.Main.Constants.WhiteListNames)" data-rooturl="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)"><i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-           </div>
-        </div>
+        <div class="settings-globalsetting" data-settingname="@Core.Helper.SystemHelper.StripBadCode(gs.SettingName, Core.Main.Constants.WhiteListNames)" data-rooturl="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)"><i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i></div>
       }
     } else {
       <div class="row">
@@ -217,22 +187,7 @@
   <div id="MarketAnalyzer_SingleMarketSettings">
     @if (Model.PTMagicConfiguration.AnalyzerSettings.SingleMarketSettings.Count > 0) {
       @foreach (Core.Main.DataObjects.PTMagicData.SingleMarketSetting sms in Model.PTMagicConfiguration.AnalyzerSettings.SingleMarketSettings) {
-        <div class="row">
-          <div class="col-md-12">
-            <div class="card-box">
-              <div class="panel-group" style="">
-                <div class="panel panel-default">
-                  <div class="panel-heading">
-                    <h3 class="panel-title"><strong><a href="#@Core.Helper.SystemHelper.StripBadCode(sms.SettingName, Core.Main.Constants.WhiteListNames)" data-toggle="collapse">SINGLE MARKET SETTING: @Core.Helper.SystemHelper.StripBadCode(sms.SettingName, Core.Main.Constants.WhiteListNames)</a></strong></h3>
-                  </div>
-                  <div id="@Core.Helper.SystemHelper.StripBadCode(sms.SettingName, Core.Main.Constants.WhiteListNames)" class="panel-collapse collapse">
-                    <div class="settings-singlemarketsetting" data-settingname="@Core.Helper.SystemHelper.StripBadCode(sms.SettingName, Core.Main.Constants.WhiteListNames)" data-rooturl="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)"><i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-           </div>
-        </div>
+        <div class="settings-singlemarketsetting" data-settingname="@Core.Helper.SystemHelper.StripBadCode(sms.SettingName, Core.Main.Constants.WhiteListNames)" data-rooturl="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)"><i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i></div>
       }
     } else {
       <div class="row">
@@ -244,6 +199,7 @@
       </div>
     }
   </div>
+
   <div id="div-loading-settings" class="row">
     <div class="col-md-12">
       <div class="card-box">
@@ -331,14 +287,18 @@
             $('.settings-markettrend.new').buildMarketTrendSettings();
             break;
           case 'GlobalSetting':
-            $('#MarketAnalyzer_GlobalSettings').append('<div class="settings-globalsetting new" data-settingname="" data-rooturl="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)"><i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i></div>');
-            $('html, body').scrollTop($('#MarketAnalyzer_GlobalSettings').offset().top + $('#MarketAnalyzer_GlobalSettings').height() - 100);
+            $('html, body').scrollTop($('#MarketAnalyzer_GlobalSettings > [data-settingname="' + dataTarget + '"]').offset().top - 100);
+            $('#MarketAnalyzer_GlobalSettings > [data-settingname="' + dataTarget + '"]').before('<div class="settings-globalsetting new" data-settingname="" data-rooturl="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)"><i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i></div>');
             $('.settings-globalsetting.new').buildGlobalSettings();
             break;
           case 'SingleMarketSetting':
-
-            $('#MarketAnalyzer_SingleMarketSettings').append('<div class="settings-singlemarketsetting new" data-settingname="" data-rooturl="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)"><i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i></div>');
-            $('html, body').scrollTop($('#MarketAnalyzer_SingleMarketSettings').offset().top + $('#MarketAnalyzer_SingleMarketSettings').height() - 100);
+            if (dataDirection === 'before') {
+              $('html, body').scrollTop($('#MarketAnalyzer_SingleMarketSettings > [data-settingname="' + dataTarget + '"]').offset().top - 100);
+              $('#MarketAnalyzer_SingleMarketSettings > [data-settingname="' + dataTarget + '"]').before('<div class="settings-singlemarketsetting new" data-settingname="" data-rooturl="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)"><i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i></div>');
+            } else {
+              $('html, body').scrollTop($('#MarketAnalyzer_SingleMarketSettings > [data-settingname="' + dataTarget + '"]').offset().top + $('#MarketAnalyzer_SingleMarketSettings > [data-settingname="' + dataTarget + '"]').height() - 100);
+              $('#MarketAnalyzer_SingleMarketSettings > [data-settingname="' + dataTarget + '"]').after('<div class="settings-singlemarketsetting new" data-settingname="" data-rooturl="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)"><i class="fa fa-circle-o-notch fa-spin fa-3x fa-fw"></i></div>');
+            }
             $('.settings-singlemarketsetting.new').buildSingleMarketSettings();
             break;
         }

--- a/PTMagic/Program.cs
+++ b/PTMagic/Program.cs
@@ -7,7 +7,7 @@ using Core.Helper;
 using Core.Main.DataObjects.PTMagicData;
 using Microsoft.Extensions.DependencyInjection;
 
-[assembly: AssemblyVersion("2.2.9")]
+[assembly: AssemblyVersion("2.2.10")]
 [assembly: AssemblyProduct("PT Magic")]
 
 namespace PTMagic


### PR DESCRIPTION
- Removed collapsing panels on the analyzer settings page, to address a bug caused by recent changes in java
- Removed "Upload Settings" option from the analyzer settings page.  It's been "coming soon"  for over a year -- the cake is a lie.
- Added strategy shortcut for "no dca buy logic" 
