### PR TITLE
.Net 3.1 upgrade and web service call fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "VS build PTMagic",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/PTMagic/bin/Debug/netcoreapp2.1/PTMagic.dll",
+            "program": "${workspaceFolder}/PTMagic/bin/Debug/netcoreapp3.1/PTMagic.dll",
             "args": [],
             "cwd": "${workspaceFolder}/PTMagic",
             "stopAtEntry": false,
@@ -28,7 +28,7 @@
             "request": "launch",
             "preLaunchTask": "VS build Monitor",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Monitor/bin/Debug/netcoreapp2.1/Monitor.dll",
+            "program": "${workspaceFolder}/Monitor/bin/Debug/netcoreapp3.1/Monitor.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Monitor",
             "stopAtEntry": false,

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -1,23 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NLog" Version="4.5.10" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="NLog" Version="4.6.8" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
     <PackageReference Include="SharpZipLib" Version="*" />
     <PackageReference Include="Telegram.Bot" Version="*" />
-  </ItemGroup>
-
-  <ItemGroup>
   </ItemGroup>
 
 </Project>

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -36,7 +36,6 @@ namespace Core.Main
     private DateTime _lastSettingFileCheck = Constants.confMinDate;
     private DateTime _lastVersionCheck = Constants.confMinDate;
     private DateTime _lastFiatCurrencyCheck = Constants.confMinDate;
-    private string _lastSetting = "";
     private string _activeSettingName = "";
     private GlobalSetting _activeSetting = null;
     private string _defaultSettingName = "";

--- a/Core/MarketAnalyzer/BaseAnalyzer.cs
+++ b/Core/MarketAnalyzer/BaseAnalyzer.cs
@@ -26,13 +26,14 @@ namespace Core.MarketAnalyzer
       request.ContentType = "application/json";
       request.UserAgent = "PTMagic.Import";
       request.KeepAlive = true;
-      request.Timeout = 60000;
+      request.Timeout = 10000;
 
       HttpWebResponse httpResponse = null;
       string jsonString = string.Empty;
 
       try
       {
+        log.DoLogInfo("Calling URL: " + url);
         httpResponse = (HttpWebResponse)request.GetResponse();
 
         using (StreamReader jsonReader = new StreamReader(httpResponse.GetResponseStream()))
@@ -72,6 +73,11 @@ namespace Core.MarketAnalyzer
         log.DoLogCritical(ex.Message, ex);
 
         throw;
+      }
+      finally
+      {
+        // Do any necessary clean up.
+        if (httpResponse != null) httpResponse.Dispose();
       }
     }
 

--- a/Core/MarketAnalyzer/Binance.cs
+++ b/Core/MarketAnalyzer/Binance.cs
@@ -26,7 +26,7 @@ namespace Core.MarketAnalyzer
         string baseUrl = "https://api.binance.com/api/v1/ticker/24hr?symbol=" + mainMarket + "USDT";
 
         log.DoLogInfo("Binance - Getting main market price...");
-        Newtonsoft.Json.Linq.JObject jsonObject = GetSimpleJsonObjectFromURL(baseUrl, log, false);
+        Newtonsoft.Json.Linq.JObject jsonObject = GetSimpleJsonObjectFromURL(baseUrl, log, null);
         if (jsonObject != null)
         {
           log.DoLogInfo("Binance - Market data received for " + mainMarket + "USDT");

--- a/Core/MarketAnalyzer/BinanceUS.cs
+++ b/Core/MarketAnalyzer/BinanceUS.cs
@@ -26,7 +26,7 @@ namespace Core.MarketAnalyzer
         string baseUrl = "https://api.binance.us/api/v1/ticker/24hr?symbol=" + mainMarket + "USDT";
 
         log.DoLogInfo("BinanceUS - Getting main market price...");
-        Newtonsoft.Json.Linq.JObject jsonObject = GetSimpleJsonObjectFromURL(baseUrl, log, false);
+        Newtonsoft.Json.Linq.JObject jsonObject = GetSimpleJsonObjectFromURL(baseUrl, log, null);
         if (jsonObject != null)
         {
           log.DoLogInfo("BinanceUS - Market data received for " + mainMarket + "USDT");

--- a/Core/MarketAnalyzer/Bittrex.cs
+++ b/Core/MarketAnalyzer/Bittrex.cs
@@ -24,7 +24,7 @@ namespace Core.MarketAnalyzer
         string baseUrl = "https://bittrex.com/api/v1.1/public/getmarketsummary?market=USDT-" + mainMarket;
 
         log.DoLogInfo("Bittrex - Getting main market price...");
-        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, "");
+        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, null);
         if (jsonObject.Count > 0)
         {
           if (jsonObject["success"])
@@ -55,7 +55,7 @@ namespace Core.MarketAnalyzer
         string baseUrl = "https://bittrex.com/api/v2.0/pub/markets/GetMarketSummaries";
 
         log.DoLogInfo("Bittrex - Getting market data...");
-        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, "");
+        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, null);
         if (jsonObject.Count > 0)
         {
           if (jsonObject["success"])
@@ -150,7 +150,7 @@ namespace Core.MarketAnalyzer
         string baseUrl = "https://bittrex.com/Api/v2.0/pub/market/GetTicks?tickInterval=oneMin&marketName=" + marketName;
 
         log.DoLogDebug("Bittrex - Getting ticks for '" + marketName + "'...");
-        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, "");
+        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, null);
         if (jsonObject.Count > 0)
         {
           if (jsonObject["success"])

--- a/Core/MarketAnalyzer/CoinMarketCap.cs
+++ b/Core/MarketAnalyzer/CoinMarketCap.cs
@@ -22,7 +22,7 @@ namespace Core.MarketAnalyzer
 
         log.DoLogInfo("CoinMarketCap - Getting market data...");
 
-        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, cmcAPI);
+        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, new (string header, string value)[] { ("X-CMC_PRO_API_KEY", cmcAPI) });
 
         if (jsonObject.Count > 0)
         {

--- a/Core/MarketAnalyzer/Poloniex.cs
+++ b/Core/MarketAnalyzer/Poloniex.cs
@@ -24,7 +24,7 @@ namespace Core.MarketAnalyzer
         string baseUrl = "https://bittrex.com/api/v1.1/public/getmarketsummary?market=USDT-" + mainMarket;
 
         log.DoLogInfo("Poloniex - Getting main market price...");
-        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, "");
+        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, null);
         if (jsonObject.Count > 0)
         {
           if (jsonObject["success"])
@@ -55,7 +55,7 @@ namespace Core.MarketAnalyzer
         string baseUrl = "https://poloniex.com/public?command=returnTicker";
 
         log.DoLogInfo("Poloniex - Getting market data...");
-        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, "");
+        Dictionary<string, dynamic> jsonObject = GetJsonFromURL(baseUrl, log, null);
         if (jsonObject.Count > 0)
         {
           log.DoLogInfo("Poloniex - Market data received for " + jsonObject.Count.ToString() + " currencies");

--- a/Core/ProfitTrailer/SettingsAPI.cs
+++ b/Core/ProfitTrailer/SettingsAPI.cs
@@ -51,12 +51,14 @@ namespace Core.ProfitTrailer
           log.DoLogDebug("Built POST request for Properties");
 
           log.DoLogInfo("Sending Properties...");
-          HttpWebResponse httpResponse = (HttpWebResponse)httpWebRequest.GetResponse();
-          log.DoLogInfo("Properties sent!");
-          httpResponse.Close();
-          log.DoLogDebug("Properties response object closed.");
+          using (HttpWebResponse httpResponse = (HttpWebResponse)httpWebRequest.GetResponse())
+          {
+            log.DoLogInfo("Properties sent!");
+            httpResponse.Close();
+            log.DoLogDebug("Properties response object closed.");
+          }
+          
           transferCompleted = true;
-
         }
         catch (WebException ex)
         {

--- a/Monitor/Monitor.csproj
+++ b/Monitor/Monitor.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <!--<PublishWithAspNetCoreTargetManifest>false</PublishWithAspNetCoreTargetManifest>-->
   </PropertyGroup>
   <ItemGroup>
@@ -23,10 +23,8 @@
     <None Include="nlog.config" CopyToOutputDirectory="Always" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />

--- a/Monitor/Pages/_get/DashboardTop.cshtml.cs
+++ b/Monitor/Pages/_get/DashboardTop.cshtml.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.AspNetCore.Http;
 using Core.Main;
 using Core.Main.DataObjects;
-using Core.Main.DataObjects.PTMagicData;
-using Core.MarketAnalyzer;
 
 namespace Monitor.Pages {
   public class DashboardTopModel : _Internal.BasePageModelSecureAJAX {

--- a/Monitor/Program.cs
+++ b/Monitor/Program.cs
@@ -4,8 +4,6 @@ using System.Security.Permissions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Core.Main;
-using Core.Helper;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Monitor
 {

--- a/PTMagic/PTMagic.csproj
+++ b/PTMagic/PTMagic.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/PTMagic/Program.cs
+++ b/PTMagic/Program.cs
@@ -5,7 +5,7 @@ using System.Security.Permissions;
 using Core.Helper;
 using Microsoft.Extensions.DependencyInjection;
 
-[assembly: AssemblyVersion("2.2.10")]
+[assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyProduct("PT Magic")]
 
 namespace PTMagic


### PR DESCRIPTION
This is a build that is upgraded to .Net Core 3.1 which is the LTS version of .Net Core and now recommended to be on for all .Net Core projects as security releases are stopping for 2.x

In addition I have upgraded to using HttpClient class for web service calls to try avoid the random thread hangs I have seen calling CoinMarketCap

I have flagged this as 3.0.0 as it is a major breaking change
.Net Core can be downloaded at https://dotnet.microsoft.com/download/dotnet-core/3.1
