### PR TITLE
Level Forumulas, etc

### DIFF
--- a/Core/DataObjects/PTMagicData.cs
+++ b/Core/DataObjects/PTMagicData.cs
@@ -464,6 +464,7 @@ namespace Core.Main.DataObjects.PTMagicData
     public DateTime FirstBoughtDate { get; set; }
     public string SellStrategy { get; set; }
     public string BuyStrategy { get; set; }
+    public double Leverage { get; set; }
     public List<Strategy> BuyStrategies { get; set; } = new List<Strategy>();
     public List<Strategy> SellStrategies { get; set; } = new List<Strategy>();
   }

--- a/Core/DataObjects/ProfitTrailerData.cs
+++ b/Core/DataObjects/ProfitTrailerData.cs
@@ -304,12 +304,13 @@ namespace Core.Main.DataObjects
         sellLogData.AverageBuyPrice = rsld.avgPrice;
         sellLogData.TotalCost = sellLogData.SoldAmount * sellLogData.AverageBuyPrice;
 
-        // check if bot is a shortbot via PT API.  Losses on short bot showing as gains. Issue #195
+        // check if bot is a shortbot via PT API.  Losses on short bot currently showing as gains. Issue #195
+        // code removed
         
-          double soldValueRaw = (sellLogData.SoldAmount * sellLogData.SoldPrice);
-          double soldValueAfterFees = soldValueRaw - (soldValueRaw * ((double)rsld.fee / 100));
-          sellLogData.SoldValue = soldValueAfterFees;
-          sellLogData.Profit = Math.Round(sellLogData.SoldValue - sellLogData.TotalCost, 8);
+        double soldValueRaw = (sellLogData.SoldAmount * sellLogData.SoldPrice);
+        double soldValueAfterFees = soldValueRaw - (soldValueRaw * ((double)rsld.fee / 100));
+        sellLogData.SoldValue = soldValueAfterFees;
+        sellLogData.Profit = Math.Round(sellLogData.SoldValue - sellLogData.TotalCost, 8);
 
         //Convert Unix Timestamp to Datetime
         System.DateTime dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);

--- a/Core/DataObjects/ProfitTrailerData.cs
+++ b/Core/DataObjects/ProfitTrailerData.cs
@@ -205,11 +205,7 @@ namespace Core.Main.DataObjects
     public double GetCurrentBalance()
     {
       return
-      (this.Summary.Balance +
-      this.Summary.PairsValue +
-      this.Summary.DCAValue +
-      this.Summary.PendingValue +
-      this.Summary.DustValue);
+      (this.Summary.Balance);
     }
     public double GetPairsBalance()
     {
@@ -365,6 +361,7 @@ namespace Core.Main.DataObjects
         dcaLogData.CurrentPrice = pair.currentPrice;
         dcaLogData.SellTrigger = pair.triggerValue == null ? 0 : pair.triggerValue;
         dcaLogData.PercChange = pair.percChange;
+        dcaLogData.Leverage = pair.leverage;
         dcaLogData.BuyStrategy = pair.buyStrategy == null ? "" : pair.buyStrategy;
         dcaLogData.SellStrategy = pair.sellStrategy == null ? "" : pair.sellStrategy;
         dcaLogData.IsTrailing = false;

--- a/Core/DataObjects/ProfitTrailerData.cs
+++ b/Core/DataObjects/ProfitTrailerData.cs
@@ -304,21 +304,12 @@ namespace Core.Main.DataObjects
         sellLogData.AverageBuyPrice = rsld.avgPrice;
         sellLogData.TotalCost = sellLogData.SoldAmount * sellLogData.AverageBuyPrice;
 
-        // check if sale was a short position
-        if ((sellLogData.ProfitPercent > 0) && (sellLogData.AverageBuyPrice > sellLogData.SoldPrice))
-        {
-          double soldValueRaw = (sellLogData.SoldAmount * sellLogData.SoldPrice);
-          double soldValueAfterFees = soldValueRaw + (soldValueRaw * ((double)rsld.fee / 100));
-          sellLogData.SoldValue = soldValueAfterFees;
-          sellLogData.Profit = Math.Abs(Math.Round(sellLogData.SoldValue - sellLogData.TotalCost, 8));
-        }
-        else
-        {
+        // check if bot is a shortbot via PT API.  Losses on short bot showing as gains. Issue #195
+        
           double soldValueRaw = (sellLogData.SoldAmount * sellLogData.SoldPrice);
           double soldValueAfterFees = soldValueRaw - (soldValueRaw * ((double)rsld.fee / 100));
           sellLogData.SoldValue = soldValueAfterFees;
           sellLogData.Profit = Math.Round(sellLogData.SoldValue - sellLogData.TotalCost, 8);
-        }
 
         //Convert Unix Timestamp to Datetime
         System.DateTime dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);

--- a/Core/DataObjects/ProfitTrailerData.cs
+++ b/Core/DataObjects/ProfitTrailerData.cs
@@ -361,7 +361,7 @@ namespace Core.Main.DataObjects
         dcaLogData.CurrentPrice = pair.currentPrice;
         dcaLogData.SellTrigger = pair.triggerValue == null ? 0 : pair.triggerValue;
         dcaLogData.PercChange = pair.percChange;
-        dcaLogData.Leverage = pair.leverage;
+        dcaLogData.Leverage = pair.leverage == null ? 0 : pair.leverage;
         dcaLogData.BuyStrategy = pair.buyStrategy == null ? "" : pair.buyStrategy;
         dcaLogData.SellStrategy = pair.sellStrategy == null ? "" : pair.sellStrategy;
         dcaLogData.IsTrailing = false;

--- a/Core/ProfitTrailer/StrategyHelper.cs
+++ b/Core/ProfitTrailer/StrategyHelper.cs
@@ -228,7 +228,7 @@ namespace Core.ProfitTrailer
         result = "";
       }
 
-      // strategy labels that are variable, so can't be caught by the switch statement
+      // strategy labels that are variable value
       if (result.Contains("REBUY"))
       {
         time = strategyName.Remove(0, 14);
@@ -423,6 +423,18 @@ namespace Core.ProfitTrailer
         case "no dca buy logic":
           result = String.Concat(strategyLetter, "NODCA");
           break;
+        case "combimagain":
+          result = String.Concat(strategyLetter, "COMBIG");
+          break;
+        case "combimaspread":
+          result = String.Concat(strategyLetter, "COMBIS");
+          break;
+        case "combimacross":
+          result = String.Concat(strategyLetter, "COMBIC");
+          break;
+        case "macdpercentage":
+          result = String.Concat(strategyLetter, "MACDPERC");
+          break;
         default:
           break;
       }
@@ -588,7 +600,7 @@ namespace Core.ProfitTrailer
           if (!isValidStrategy)
           {
             // Parse Formulas
-            if (strategy.Name.Contains("FORMULA") && !strategy.Name.Contains("STATS"))
+            if (strategy.Name.Contains("FORMULA") && !strategy.Name.Contains("STATS") && !strategy.Name.Contains("LEVEL"))
             {
               string expression = strategy.Name.Remove(0, 10);
               expression = expression.Replace("<span class=\"tdgreen\">", "true").Replace("<span class=\"red\">", "false").Replace("</span>", "").Replace("&&", "and").Replace("||", "or");
@@ -605,10 +617,43 @@ namespace Core.ProfitTrailer
               }
 
             }
-            else
+            //else
+            //{
+            //  strategyText += "<span class=\"label label-warning\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"" + strategy.Name + "\">" + StrategyHelper.GetStrategyShortcut(strategy.Name, false) + "</span> ";
+            //}
+
+
+            if (strategy.Name.Contains("LEVEL") && !strategy.Name.Contains("TRIGGERED"))
             {
-              strategyText += "<span class=\"label label-warning\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"" + strategy.Name + "\">" + StrategyHelper.GetStrategyShortcut(strategy.Name, false) + "</span> ";
+              string level = strategy.Name.Substring(5, 2);
+              string expression = strategy.Name.Remove(0, 17);
+              expression = expression.Replace("<span class=\"tdgreen\">", "true").Replace("<span class=\"red\">", "false").Replace("</span>", "").Replace("&&", "and").Replace("||", "or");
+              expression = regx.Replace(expression, String.Empty);
+              var tokens = new Tokenizer(expression).Tokenize();
+              var parser = new Parser(tokens);
+              if (parser.Parse())
+              {
+                strategyText += "<span class=\"label label-success\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"LEVEL FORMULA\">LEVEL" + level + "</span> ";
+              }
+              else
+              {
+                strategyText += "<span class=\"label label-danger\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"LEVEL FORMULA\">LEVEL" + level + "</span> ";
+              }
+
             }
+            //else
+            //{
+            //  strategyText += "<span class=\"label label-warning\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"" + strategy.Name + "\">" + StrategyHelper.GetStrategyShortcut(strategy.Name, false) + "</span> ";
+            //}
+
+            if (strategy.Name.Contains("LEVEL") && strategy.Name.Contains("TRIGGERED"))
+            {
+              string level = strategy.Name.Substring(5, 2);
+              strategyText += "<span class=\"label label-success\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"CONDITIONAL FORMULA\">LEVEL " + level + "TRIG</span> ";
+            }
+
+
+
           }
           else
           {

--- a/Core/ProfitTrailer/StrategyHelper.cs
+++ b/Core/ProfitTrailer/StrategyHelper.cs
@@ -238,7 +238,7 @@ namespace Core.ProfitTrailer
       {
         leverage = strategyName.Remove(0, 9);
         leverage = leverage.Remove(leverage.Length - 1, 1);
-        result = "CROSS" + leverage + "X";
+        result = "CROSS " + leverage + "X";
       }
       if (result.Contains("ISOLATED"))
       {

--- a/Core/ProfitTrailer/StrategyHelper.cs
+++ b/Core/ProfitTrailer/StrategyHelper.cs
@@ -601,7 +601,7 @@ namespace Core.ProfitTrailer
             else if (strategy.Name.Contains("STATS"))
             // avoid parsing advanced buy stats
             {
-              strategyText += "";
+              strategy.Name = "";
             }
             else if (strategy.Name.Contains("FORMULA"))
             // Parse Various PT Formulas

--- a/Core/ProfitTrailer/StrategyHelper.cs
+++ b/Core/ProfitTrailer/StrategyHelper.cs
@@ -168,12 +168,9 @@ namespace Core.ProfitTrailer
             boolean = boolean && nextBoolean;
           else
             boolean = boolean || nextBoolean;
-
         }
-
         return boolean;
       }
-
       throw new Exception("Empty expression");
     }
 
@@ -227,7 +224,6 @@ namespace Core.ProfitTrailer
       {
         result = "";
       }
-
       // strategy labels that are variable value
       if (result.Contains("REBUY"))
       {
@@ -244,7 +240,6 @@ namespace Core.ProfitTrailer
         leverage = leverage.Remove(leverage.Length - 1, 1);
         result = leverage + " X";
       }
-
       // buy/sell strategies beginning with PT 2.3.3 contain the strategy designation letter followed by a colon and space.
       // remove the letter and colon, change to shortcut, then reapply the letter and colon
       if (strategyName.Contains(":"))
@@ -446,7 +441,6 @@ namespace Core.ProfitTrailer
           result = "";
         }
       }
-
       return result;
     }
 
@@ -534,14 +528,12 @@ namespace Core.ProfitTrailer
           result = true;
         }
       }
-
       return result;
     }
 
     public static int GetStrategyValueDecimals(string strategyName)
     {
       int result = 0;
-
       switch (strategyName.ToLower())
       {
         case "lowbb":
@@ -580,7 +572,6 @@ namespace Core.ProfitTrailer
         default:
           break;
       }
-
       return result;
     }
 
@@ -615,14 +606,7 @@ namespace Core.ProfitTrailer
               {
                 strategyText += "<span class=\"label label-danger\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"CONDITIONAL FORMULA\">(FORM)</span> ";
               }
-
             }
-            //else
-            //{
-            //  strategyText += "<span class=\"label label-warning\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"" + strategy.Name + "\">" + StrategyHelper.GetStrategyShortcut(strategy.Name, false) + "</span> ";
-            //}
-
-
             if (strategy.Name.Contains("LEVEL") && !strategy.Name.Contains("TRIGGERED"))
             {
               string level = strategy.Name.Substring(5, 2);
@@ -639,21 +623,12 @@ namespace Core.ProfitTrailer
               {
                 strategyText += "<span class=\"label label-danger\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"LEVEL FORMULA\">LEVEL" + level + "</span> ";
               }
-
             }
-            //else
-            //{
-            //  strategyText += "<span class=\"label label-warning\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"" + strategy.Name + "\">" + StrategyHelper.GetStrategyShortcut(strategy.Name, false) + "</span> ";
-            //}
-
             if (strategy.Name.Contains("LEVEL") && strategy.Name.Contains("TRIGGERED"))
             {
               string level = strategy.Name.Substring(5, 2);
               strategyText += "<span class=\"label label-success\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"CONDITIONAL FORMULA\">LEVEL " + level + "TRIG</span> ";
             }
-
-
-
           }
           else
           {
@@ -761,14 +736,12 @@ namespace Core.ProfitTrailer
           result = simpleValue.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + "%";
         }
       }
-
       return result;
     }
 
     public static string GetTriggerValueText(Summary summary, List<Strategy> strategies, string strategyText, double bbValue, double simpleValue, int buyLevel, bool includeShortcut)
     {
       string result = "";
-
       if (strategies.Count > 0)
       {
         foreach (Strategy strategy in strategies)
@@ -783,12 +756,10 @@ namespace Core.ProfitTrailer
             {
               decimalFormat += "0";
             }
-
             if (includeShortcut)
             {
               result += "<span class=\"text-muted\">" + StrategyHelper.GetStrategyShortcut(strategy.Name, true) + "</span> ";
             }
-
             if (StrategyHelper.GetStrategyShortcut(strategy.Name, true).IndexOf("and", StringComparison.InvariantCultureIgnoreCase) > -1)
             {
               result += strategy.TriggerValue.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"));
@@ -832,7 +803,6 @@ namespace Core.ProfitTrailer
           result = simpleValue.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + "%";
         }
       }
-
       return result;
     }
   }

--- a/Monitor/Pages/_get/DashboardBottom.cshtml
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml
@@ -107,7 +107,8 @@
         double totalProfitFiat = Math.Round(totalProfit * Model.Summary.MainMarketPrice, 2);
         double percentGain = Math.Round(totalProfit / Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance * 100, 2);
         string percentGainText = percentGain.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + "%";
-        if (Model.PTData.TransactionData.Transactions.Count > 0) {
+        if (Model.PTData.TransactionData.Transactions.Count > 0) 
+        {
           percentGainText = "<i class=\"fa fa-info-circle text-muted\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"You have added at least one manual transaction, so the total gain percentage cannot be calculated.\"></i>";
         }
 
@@ -205,12 +206,10 @@
             .donut(true)          //Turn on Donut mode. Makes pie chart look tasty!
             .donutRatio(0.3)     //Configure how big you want the donut hole size to be.
             ;
-
         d3.select("#AssetDistribution svg")
           .datum(@Html.Raw(Model.AssetDistributionData))
           .transition().duration(350)
           .call(chart);
-
         return chart;
       });
       </text>
@@ -228,7 +227,6 @@
         $.Notification.notify('success', 'top left', '@Core.Helper.SystemHelper.SplitCamelCase(Model.Summary.CurrentGlobalSetting.SettingName) now active!', 'PTMagic switched Profit Trailer settings to "@Core.Helper.SystemHelper.SplitCamelCase(Model.Summary.CurrentGlobalSetting.SettingName)".');
       </text>
     }
-
     @if (!Model.TrendChartDataJSON.Equals("")) {
       <text>
         nv.addGraph(function () {
@@ -244,7 +242,6 @@
       });
       </text>
     }
-
     @if (!Model.ProfitChartDataJSON.Equals("")) {
       <text>
         nv.addGraph(function () {
@@ -256,7 +253,6 @@
         lineChart.yAxis.axisLabel('Daily Profit').tickFormat(d3.format(',.2f'));
         d3.select('.profit-chart svg').attr('perserveAspectRatio', 'xMinYMid').datum(chartData).transition().duration(500).call(lineChart);
         //nv.utils.windowResize(lineChart.update); v1.3.0 => Removed this line to prevent memory leak
-
         return lineChart;
       });
       </text>

--- a/Monitor/Pages/_get/DashboardBottom.cshtml
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml
@@ -10,7 +10,7 @@
 }
 
 <div class="row">
-  <div class="col-md-5 px-1">
+  <div class="col-md-4 px-1">
     <div class="card-box px-2" style="height:305px;">
       <div class="cdev" data-percent="100" data-duration="@Html.Raw(@Model.PTMagicConfiguration.GeneralSettings.Monitor.RefreshSeconds * 1000)" data-color="#aaa,#414d59"></div>
       @if (!Model.TrendChartDataJSON.Equals("")) {
@@ -22,9 +22,9 @@
       }
     </div>
   </div>
-  <div class="col-md-2 px-1">
-    <div class="card-box px-2" style="height:305px;">
-      
+  <div class="col-md-3 px-1">
+    <div class="card-box px-3" style="height:305px;">
+      <div class="cdev" data-percent="100" data-duration="@Html.Raw(@Model.PTMagicConfiguration.GeneralSettings.Monitor.RefreshSeconds * 1000)" data-color="#aaa,#414d59"></div>
       @{
       double currentBalance = Model.PTData.GetCurrentBalance();
       string currentBalanceString = currentBalance.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US"));
@@ -32,16 +32,18 @@
         currentBalanceString = Math.Round(currentBalance, 2).ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"));
         }
       }
-      <div class="text-center">
-        <small>TCV: &nbsp; <text class="text-autocolor"> @currentBalanceString &nbsp; @Model.Summary.MainMarket &nbsp; </text> </small></div>   
+      <div class="text-center"><small>TCV: &nbsp; <text class="text-autocolor"> @currentBalanceString &nbsp; @Model.Summary.MainMarket &nbsp; </text> </small></div>   
       <div id="AssetDistribution">
-        <svg style="height:290px;width:100%"></svg>
+        <svg style="height:230px;width:100%"></svg>
+        <div class="text">
+          <small>Start: &nbsp; <text class="text-autocolor"> @Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance @Model.Summary.MainMarket </text>
+          <text class="pull-right">Gain: &nbsp; <text class="text-autocolor"> @Math.Round(((currentBalance - Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance) / Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance) * 100, 2) %</text></small>
+        </div>
       </div>
     </div>
   </div>
   <div class="col-md-5 px-1">
-   
-
+    <div class="cdev" data-percent="100" data-duration="@Html.Raw(@Model.PTMagicConfiguration.GeneralSettings.Monitor.RefreshSeconds * 1000)" data-color="#aaa,#414d59"></div>
     <div class="card-box px-2" style="height:305px;">
       @if (!Model.ProfitChartDataJSON.Equals("")) {
         <div class="profit-chart">
@@ -53,14 +55,13 @@
     </div>
   </div>
 </div>
-
-
 <div class="row">
   <div class="col-md-6 px-1">
     <div class="card-box px-2">
+      <div class="cdev" data-percent="100" data-duration="@Html.Raw(@Model.PTMagicConfiguration.GeneralSettings.Monitor.RefreshSeconds * 1000)" data-color="#aaa,#414d59"></div>
+      <br>
       <h4 class="m-t-0 m-b-20 header-title"><b>Market Trends at @Model.PTMagicConfiguration.GeneralSettings.Application.Exchange</b>
       <small class="pull-right"><a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)MarketAnalyzer">more</a></small></h4>
-
       <table class="table table-sm">
         <thead>
           <tr>
@@ -98,8 +99,9 @@
   </div>
   
   <div class="col-md-6 px-1">
-
     <div class="card-box px-2">
+      <div class="cdev" data-percent="100" data-duration="@Html.Raw(@Model.PTMagicConfiguration.GeneralSettings.Monitor.RefreshSeconds * 1000)" data-color="#aaa,#414d59"></div>
+      <br>
       <h4 class="m-t-0 m-b-20 header-title"><b>Sales Overview</b><small class="pull-right"><a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)SalesAnalyzer">more</a></small></h4>
      @{
         double totalProfit = Model.PTData.SellLog.Sum(s => s.Profit);
@@ -178,7 +180,6 @@
           </tr>
         </tbody>
       </table>
-       <small class="pull-right">Starting Balance: &nbsp; @Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance @Model.Summary.MainMarket</small>
     </div>
   </div>
 </div>
@@ -200,7 +201,7 @@
             .x(function(d) { return d.label })
             .y(function(d) { return d.value })
             .showLabels(true)     //Display pie labels
-            .labelThreshold(.1)  //Configure the minimum slice size for labels to show up
+            .labelThreshold(.1)   //Configure the minimum slice size for labels to show up
             .labelType("percent") //Configure what type of data to show in the label. Can be "key", "value" or "percent"
             .donut(true)          //Turn on Donut mode. Makes pie chart look tasty!
             .donutRatio(0.3)     //Configure how big you want the donut hole size to be.

--- a/Monitor/Pages/_get/DashboardBottom.cshtml
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml
@@ -26,18 +26,17 @@
     <div class="card-box px-3" style="height:305px;">
       <div class="cdev" data-percent="100" data-duration="@Html.Raw(@Model.PTMagicConfiguration.GeneralSettings.Monitor.RefreshSeconds * 1000)" data-color="#aaa,#414d59"></div>
       @{
-      double currentBalance = Model.PTData.GetCurrentBalance();
-      string currentBalanceString = currentBalance.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US"));
-      if (currentBalance > 100) {
-        currentBalanceString = Math.Round(currentBalance, 2).ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"));
+      string totalCurrentValueString = Model.totalCurrentValue.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US"));
+      if (Model.totalCurrentValue > 100) {
+        totalCurrentValueString = Math.Round(Model.totalCurrentValue, 2).ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"));
         }
       }
-      <div class="text-center"><small>TCV: &nbsp; <text class="text-autocolor"> @currentBalanceString &nbsp; @Model.Summary.MainMarket &nbsp; </text> </small></div>   
+      <div class="text-center"><small>TCV: &nbsp; <text class="text-autocolor"> @totalCurrentValueString &nbsp; @Model.Summary.MainMarket &nbsp; </text> </small></div>   
       <div id="AssetDistribution">
         <svg style="height:230px;width:100%"></svg>
         <div class="text">
           <small>Start: &nbsp; <text class="text-autocolor"> @Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance @Model.Summary.MainMarket </text>
-          <text class="pull-right">Gain: &nbsp; <text class="text-autocolor"> @Math.Round(((currentBalance - Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance) / Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance) * 100, 2) %</text></small>
+          <text class="pull-right">Gain: &nbsp; <text class="text-autocolor"> @Math.Round(((Model.totalCurrentValue - Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance) / Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance) * 100, 2) %</text></small>
         </div>
       </div>
     </div>

--- a/Monitor/Pages/_get/DashboardBottom.cshtml
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml
@@ -13,7 +13,6 @@
   <div class="col-md-5 px-1">
     <div class="card-box px-2" style="height:305px;">
       <div class="cdev" data-percent="100" data-duration="@Html.Raw(@Model.PTMagicConfiguration.GeneralSettings.Monitor.RefreshSeconds * 1000)" data-color="#aaa,#414d59"></div>
-  
       @if (!Model.TrendChartDataJSON.Equals("")) {
         <div class="trend-chart">
           <svg style="height: 300px;width: 100%;"></svg>
@@ -25,7 +24,7 @@
   </div>
   <div class="col-md-2 px-1">
     <div class="card-box px-2" style="height:305px;">
-      <div class="cdev" data-percent="100" data-duration="@Html.Raw(@Model.PTMagicConfiguration.GeneralSettings.Monitor.RefreshSeconds * 1000)" data-color="#aaa,#414d59"></div>
+      
       @{
       double currentBalance = Model.PTData.GetCurrentBalance();
       string currentBalanceString = currentBalance.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US"));
@@ -34,21 +33,14 @@
         }
       }
       <div class="text-center">
-        <small>
-          Start balence: &nbsp; <text class="text-autocolor"> @Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance @Model.Summary.MainMarket</text>
-          <br>
-          Current value: &nbsp; <text class="text-autocolor"> @currentBalanceString @Model.Summary.MainMarket</text>
-          <br>
-          Gain: &nbsp; <text class="text-autocolor"> @Math.Round(((currentBalance - Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance) / Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance) * 100, 2) %</text>
-       </small>
-      </div>      
+        <small>TCV: &nbsp; <text class="text-autocolor"> @currentBalanceString &nbsp; @Model.Summary.MainMarket &nbsp; </text> </small></div>   
       <div id="AssetDistribution">
-        <svg style="height:230px;width:100%"></svg>
+        <svg style="height:290px;width:100%"></svg>
       </div>
     </div>
   </div>
   <div class="col-md-5 px-1">
-    <div class="cdev" data-percent="100" data-duration="@Html.Raw(@Model.PTMagicConfiguration.GeneralSettings.Monitor.RefreshSeconds * 1000)" data-color="#aaa,#414d59"></div>
+   
 
     <div class="card-box px-2" style="height:305px;">
       @if (!Model.ProfitChartDataJSON.Equals("")) {
@@ -65,11 +57,9 @@
 
 <div class="row">
   <div class="col-md-6 px-1">
-    <div class="cdev" data-percent="100" data-duration="@Html.Raw(@Model.PTMagicConfiguration.GeneralSettings.Monitor.RefreshSeconds * 1000)" data-color="#aaa,#414d59"></div>
-
     <div class="card-box px-2">
-      <br/>
-      <h4 class="m-t-0 m-b-20 header-title"><b>Market Trends at @Model.PTMagicConfiguration.GeneralSettings.Application.Exchange</b><small class="pull-right"><a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)MarketAnalyzer">more</a></small></h4>
+      <h4 class="m-t-0 m-b-20 header-title"><b>Market Trends at @Model.PTMagicConfiguration.GeneralSettings.Application.Exchange</b>
+      <small class="pull-right"><a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)MarketAnalyzer">more</a></small></h4>
 
       <table class="table table-sm">
         <thead>
@@ -108,12 +98,10 @@
   </div>
   
   <div class="col-md-6 px-1">
-    <div class="cdev" data-percent="100" data-duration="@Html.Raw(@Model.PTMagicConfiguration.GeneralSettings.Monitor.RefreshSeconds * 1000)" data-color="#aaa,#414d59"></div>
 
     <div class="card-box px-2">
-      <br/>
       <h4 class="m-t-0 m-b-20 header-title"><b>Sales Overview</b><small class="pull-right"><a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)SalesAnalyzer">more</a></small></h4>
-      @{
+     @{
         double totalProfit = Model.PTData.SellLog.Sum(s => s.Profit);
         double totalProfitFiat = Math.Round(totalProfit * Model.Summary.MainMarketPrice, 2);
         double percentGain = Math.Round(totalProfit / Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance * 100, 2);
@@ -190,6 +178,7 @@
           </tr>
         </tbody>
       </table>
+       <small class="pull-right">Starting Balance: &nbsp; @Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance @Model.Summary.MainMarket</small>
     </div>
   </div>
 </div>

--- a/Monitor/Pages/_get/DashboardBottom.cshtml.cs
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml.cs
@@ -52,7 +52,6 @@ namespace Monitor.Pages {
       BuildMarketTrendChartData();
       BuildProfitChartData();
     }
-
     private void BuildMarketTrendChartData() {
       if (MarketTrends.Count > 0) {
         TrendChartDataJSON = "[";
@@ -99,13 +98,10 @@ namespace Monitor.Pages {
                   MarketTrendChange mtc = latestTickRange.First();
                   if (trendChartTicks > 0) TrendChartDataJSON += ",\n";
                   if (Double.IsInfinity(mtc.TrendChange)) mtc.TrendChange = 0;
-
                   TrendChartDataJSON += "{ x: new Date('" + mtc.TrendDateTime.ToString("yyyy-MM-ddTHH:mm:ss").Replace(".", ":") + "'), y: " + mtc.TrendChange.ToString("0.00", new System.Globalization.CultureInfo("en-US")) + "}";
                 }
-
                 TrendChartDataJSON += "]";
                 TrendChartDataJSON += "}";
-
                 mtIndex++;
               }
             }
@@ -143,6 +139,7 @@ namespace Monitor.Pages {
     }
     private void BuildAssetDistributionData()
     {
+      // the per PT-Eelroy, the PT API doesn't provide these values when using leverage, so they are calculated here to cover either case.
       double PairsBalance = 0.0;
       double DCABalance = 0.0;
       double PendingBalance = 0.0;
@@ -152,14 +149,9 @@ namespace Monitor.Pages {
         
       foreach (Core.Main.DataObjects.PTMagicData.DCALogData dcaLogEntry in PTData.DCALog) 
       {
-        // Loop through the pairs preparing the data for display
         Core.Main.DataObjects.PTMagicData.MarketPairSummary mps = null;
         string sellStrategyText = Core.ProfitTrailer.StrategyHelper.GetStrategyText(Summary, dcaLogEntry.SellStrategies, dcaLogEntry.SellStrategy, isSellStrategyTrue, isTrailingSellActive);
-        bool dcaEnabled = true;
-        if (mps != null) 
-        {
-          dcaEnabled = mps.IsDCAEnabled;
-        }
+
         // Aggregate totals
         if (dcaLogEntry.Leverage == 0)
         {
@@ -167,7 +159,7 @@ namespace Monitor.Pages {
           {
           PendingBalance = PendingBalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice); 
           }
-          else if (dcaEnabled) 
+          else if (dcaLogEntry.BuyStrategies.Count > 0) 
           {
           DCABalance = DCABalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice);          
           }
@@ -182,7 +174,7 @@ namespace Monitor.Pages {
           {
           PendingBalance = PendingBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage); 
           }
-          else if (dcaEnabled) 
+          else if (dcaLogEntry.BuyStrategies.Count > 0) 
           {
           DCABalance = DCABalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage);          
           }
@@ -191,22 +183,13 @@ namespace Monitor.Pages {
           PairsBalance = PairsBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage);
           }
         }
-       
       }
-      
       totalCurrentValue = PendingBalance + DCABalance + PairsBalance + AvailableBalance;
-
       AssetDistributionData = "[";
       AssetDistributionData += "{label: 'Pairs',color: '#82E0AA',value: '" + PairsBalance.ToString("0.00", new System.Globalization.CultureInfo("en-US")) + "'},";
       AssetDistributionData += "{label: 'DCA',color: '#D98880',value: '" + DCABalance.ToString("0.00", new System.Globalization.CultureInfo("en-US")) + "'},";
       AssetDistributionData += "{label: 'Pending',color: '#F5B041',value: '" + PendingBalance.ToString("0.00", new System.Globalization.CultureInfo("en-US")) + "'},";
       AssetDistributionData += "{label: 'Balance',color: '#85C1E9',value: '" + AvailableBalance.ToString("0.00", new System.Globalization.CultureInfo("en-US")) + "'}]";
     }
-
-
-
-
-
-
   }
 }

--- a/Monitor/Pages/_get/DashboardBottom.cshtml.cs
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml.cs
@@ -21,6 +21,7 @@ namespace Monitor.Pages {
     public string currentBalanceString = "";
     public double TotalBagCost = 0;
     public double TotalBagValue = 0;
+    public double totalCurrentValue = 0;
     public void OnGet() {
       // Initialize Config
       base.Init();
@@ -160,24 +161,52 @@ namespace Monitor.Pages {
           dcaEnabled = mps.IsDCAEnabled;
         }
         // Aggregate totals
-        if (sellStrategyText.Contains("PENDING"))
+        if (dcaLogEntry.Leverage == 0)
         {
-        PendingBalance = PendingBalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice); 
-        }
-        else if (dcaEnabled) 
-        {
-        DCABalance = DCABalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice);          
+          if (sellStrategyText.Contains("PENDING"))
+          {
+          PendingBalance = PendingBalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice); 
+          }
+          else if (dcaEnabled) 
+          {
+          DCABalance = DCABalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice);          
+          }
+          else
+          {
+          PairsBalance = PairsBalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice);
+          }
         }
         else
         {
-        PairsBalance = PairsBalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice);
+          if (sellStrategyText.Contains("PENDING"))
+          {
+          PendingBalance = PendingBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage); 
+          }
+          else if (dcaEnabled) 
+          {
+          DCABalance = DCABalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage);          
+          }
+          else
+          {
+          PairsBalance = PairsBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage);
+          }
         }
+       
       }
+      
+      totalCurrentValue = PendingBalance + DCABalance + PairsBalance + AvailableBalance;
+
       AssetDistributionData = "[";
       AssetDistributionData += "{label: 'Pairs',color: '#82E0AA',value: '" + PairsBalance.ToString("0.00", new System.Globalization.CultureInfo("en-US")) + "'},";
       AssetDistributionData += "{label: 'DCA',color: '#D98880',value: '" + DCABalance.ToString("0.00", new System.Globalization.CultureInfo("en-US")) + "'},";
       AssetDistributionData += "{label: 'Pending',color: '#F5B041',value: '" + PendingBalance.ToString("0.00", new System.Globalization.CultureInfo("en-US")) + "'},";
       AssetDistributionData += "{label: 'Balance',color: '#85C1E9',value: '" + AvailableBalance.ToString("0.00", new System.Globalization.CultureInfo("en-US")) + "'}]";
     }
+
+
+
+
+
+
   }
 }

--- a/Monitor/Pages/_get/DashboardBottom.cshtml.cs
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml.cs
@@ -153,17 +153,13 @@ namespace Monitor.Pages {
       {
         // Loop through the pairs preparing the data for display
         Core.Main.DataObjects.PTMagicData.MarketPairSummary mps = null;
-        
         string sellStrategyText = Core.ProfitTrailer.StrategyHelper.GetStrategyText(Summary, dcaLogEntry.SellStrategies, dcaLogEntry.SellStrategy, isSellStrategyTrue, isTrailingSellActive);
-
         bool dcaEnabled = true;
         if (mps != null) 
         {
           dcaEnabled = mps.IsDCAEnabled;
         }
-
         // Aggregate totals
-
         if (sellStrategyText.Contains("PENDING"))
         {
         PendingBalance = PendingBalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice); 

--- a/Monitor/Pages/_get/DashboardTop.cshtml
+++ b/Monitor/Pages/_get/DashboardTop.cshtml
@@ -147,25 +147,20 @@
                   buyDisabled = true;
                 }
 
-
-
+                // if leverage, recalculate profit target
                 if (buyStrategyText.Contains("CROSSED"))
                 {
                   string leverageText = buyStrategyText.Remove(0, buyStrategyText.IndexOf("CROSSED")+9);
                   leverage = leverageText.Remove(leverageText.IndexOf(".0)"), leverageText.Length - leverageText.IndexOf(".0)"));
                   leverageValue = double.Parse(leverage);
-                  Write(leverageValue); 
                 }
                 if (buyStrategyText.Contains("ISOLATED"))
                 {
-                  leverage = buyStrategyText.Remove(0, 10);
-                  leverage = leverage.Remove(leverage.Length - 3, 3);
-                  //leverageValue = double.Parse(leverage);
-                  Write(leverage); 
+                  string leverageText = buyStrategyText.Remove(0, buyStrategyText.IndexOf("ISOLATED")+10);
+                  leverage = leverageText.Remove(leverageText.IndexOf(".0)"), leverageText.Length - leverageText.IndexOf(".0)"));
+                  leverageValue = double.Parse(leverage);
                 }
-
-
-
+                
                 string sellStrategyText = Core.ProfitTrailer.StrategyHelper.GetStrategyText(Model.Summary, dcaLogEntry.SellStrategies, dcaLogEntry.SellStrategy, isSellStrategyTrue, isTrailingSellActive);
 
                 // Check for when PT loses the value of a pair

--- a/Monitor/Pages/_get/DashboardTop.cshtml
+++ b/Monitor/Pages/_get/DashboardTop.cshtml
@@ -93,12 +93,12 @@
             <thead>
               <tr>
                 <th>Market</th>             
-                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Market trend last 24 hours">24H Trend</th>
+                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Market trend last 24 hours">24H</th>
                 <th class="text-left" data-toggle="tooltip" data-placement="top" title="Total Buy Cost">Cost</th>
                 <th></th>
-                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Active buy strategies">DCA Buy Strats</th>
-                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Active sell strategies">Sell Strats</th>
-                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Target Profit for sale">Target Profit</th>
+                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Active buy strategies">DCA</th>
+                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Active sell strategies">Sell</th>
+                <th class="text-left" data-toggle="tooltip" data-placement="top" title="Target profit to sell">Target</th>
                 <th class="text-left" data-toggle="tooltip" data-placement="top" title="Current Profit">Profit</th>
                 <th></th>
               </tr>
@@ -137,10 +137,34 @@
                 }
 
                 bool buyDisabled = false;
+                string leverage = "";
+                double leverageValue = 0;
+
                 string buyStrategyText = Core.ProfitTrailer.StrategyHelper.GetStrategyText(Model.Summary, dcaLogEntry.BuyStrategies, dcaLogEntry.BuyStrategy, isBuyStrategyTrue, isTrailingBuyActive);
-                if (!Core.ProfitTrailer.StrategyHelper.IsValidStrategy(buyStrategyText, true)) {
+
+                if (!Core.ProfitTrailer.StrategyHelper.IsValidStrategy(buyStrategyText, true)) 
+                {
                   buyDisabled = true;
                 }
+
+
+
+                if (buyStrategyText.Contains("CROSSED"))
+                {
+                  string leverageText = buyStrategyText.Remove(0, buyStrategyText.IndexOf("CROSSED")+9);
+                  leverage = leverageText.Remove(leverageText.IndexOf(".0)"), leverageText.Length - leverageText.IndexOf(".0)"));
+                  leverageValue = double.Parse(leverage);
+                  Write(leverageValue); 
+                }
+                if (buyStrategyText.Contains("ISOLATED"))
+                {
+                  leverage = buyStrategyText.Remove(0, 10);
+                  leverage = leverage.Remove(leverage.Length - 3, 3);
+                  //leverageValue = double.Parse(leverage);
+                  Write(leverage); 
+                }
+
+
 
                 string sellStrategyText = Core.ProfitTrailer.StrategyHelper.GetStrategyText(Model.Summary, dcaLogEntry.SellStrategies, dcaLogEntry.SellStrategy, isSellStrategyTrue, isTrailingSellActive);
 
@@ -197,13 +221,20 @@
                       <span data-toggle="tooltip" data-placement="top" title="DCA is disabled"><i class="fa fa-ban text-highlight"></i></span>
                     }
                   </td>
-
                   <td>@Html.Raw(buyStrategyText)</td>
-
                   <td>@Html.Raw(sellStrategyText)</td>
                   
-                  <td class="@Html.Raw((dcaLogEntry.TargetGainValue.HasValue && (dcaLogEntry.ProfitPercent > dcaLogEntry.TargetGainValue.Value)) ? "text-success" : "text-danger")">@Html.Raw(dcaLogEntry.TargetGainValue.HasValue ? dcaLogEntry.TargetGainValue.Value.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + "%" : "&nbsp")</td>
-
+                  
+                  @if (leverageValue == 0)
+                  {
+                    <td class="@Html.Raw((dcaLogEntry.TargetGainValue.HasValue && (dcaLogEntry.ProfitPercent > dcaLogEntry.TargetGainValue.Value)) ? "text-success" : "text-danger")">@Html.Raw(dcaLogEntry.TargetGainValue.HasValue ? dcaLogEntry.TargetGainValue.Value.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + "%" : "&nbsp")</td>
+                  }
+                  else
+                  {
+                    double leverageTargetGain = leverageValue * dcaLogEntry.TargetGainValue.Value;
+                    <td class="@Html.Raw((dcaLogEntry.TargetGainValue.HasValue && (dcaLogEntry.ProfitPercent > dcaLogEntry.TargetGainValue.Value)) ? "text-success" : "text-danger")">@Html.Raw(dcaLogEntry.TargetGainValue.HasValue ? leverageTargetGain.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + "%" : "&nbsp")</td>
+                  }
+                  
                   @if(!@lostValue)
                   {
                     <td class="text-autocolor">@dcaLogEntry.ProfitPercent.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"))%</td>

--- a/Monitor/Pages/_get/DashboardTop.cshtml
+++ b/Monitor/Pages/_get/DashboardTop.cshtml
@@ -224,8 +224,9 @@
             <td></td>
             <td></td>
             <td></td>
-            <td class="text-autocolor">@Html.Raw((((Model.TotalBagValue - Model.TotalBagCost) / Model.TotalBagCost) * 100).ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")))%</td>
 
+            <td class="text-autocolor">@Html.Raw( (((Model.TotalBagValue - Model.TotalBagCost) / Model.TotalBagCost) * 100).ToString("#0.00", new System.Globalization.CultureInfo("en-US")))%</td>
+            
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
- Fixed issue #198 where Level formulas were crashing the monitor. Added code to make them compatible with the boolean parser, and added new shortcuts for level and level triggered formulas.

- Added shortcuts for a few new strategies

- Removed redundant refresh timers on dashboard bottom -- one timer should be enough.

- Reverted changes to distribution chart: starting balance and total gain make no sense on a chart designed to show current distribution of TCV.  Also, total gain is already visible at the bottom of the dashboard sales widget. Added starting balance to the bottom of the sales widget (makes more sense to have it here).