### PR TITLE
Fixes for settings and trend data not refreshing

### DIFF
--- a/Core/Main/PTMagicConfiguration.cs
+++ b/Core/Main/PTMagicConfiguration.cs
@@ -15,15 +15,23 @@ namespace Core.Main
     private GeneralSettings _generalSettings = null;
     private AnalyzerSettings _analyzerSettings = null;
     private SecureSettings _secureSettings = null;
+    private string _basePath;
 
     public PTMagicConfiguration()
     {
-      LoadSettings(Directory.GetCurrentDirectory());
+      _basePath = Directory.GetCurrentDirectory();
+      LoadSettings(_basePath);
     }
 
     public PTMagicConfiguration(string basePath)
     {
-      LoadSettings(basePath);
+      _basePath = basePath;
+      LoadSettings(_basePath);
+    }
+
+    public void RefreshSettings()
+    {
+      LoadSettings(_basePath);
     }
 
     private void LoadSettings(string basePath)
@@ -100,17 +108,17 @@ namespace Core.Main
       }
     }
 
-    public void WriteGeneralSettings(string basePath)
+    public void WriteGeneralSettings()
     {
       GeneralSettingsWrapper gsWrapper = new GeneralSettingsWrapper();
       gsWrapper.GeneralSettings = this.GeneralSettings;
 
-      FileHelper.CreateBackup(basePath + "settings.general.json", basePath, "settings.general.json.backup");
+      FileHelper.CreateBackup(_basePath + "settings.general.json", _basePath, "settings.general.json.backup");
 
-      FileHelper.WriteTextToFile(basePath, "settings.general.json", JsonConvert.SerializeObject(gsWrapper, Formatting.Indented));
+      FileHelper.WriteTextToFile(_basePath, "settings.general.json", JsonConvert.SerializeObject(gsWrapper, Formatting.Indented));
     }
 
-    public void WriteAnalyzerSettings(string basePath)
+    public void WriteAnalyzerSettings()
     {
       AnalyzerSettingsWrapper asWrapper = new AnalyzerSettingsWrapper();
       asWrapper.AnalyzerSettings = this.AnalyzerSettings;
@@ -119,12 +127,12 @@ namespace Core.Main
       settings.NullValueHandling = NullValueHandling.Ignore;
       settings.DefaultValueHandling = DefaultValueHandling.Ignore;
 
-      FileHelper.CreateBackup(basePath + "settings.analyzer.json", basePath, "settings.analyzer.json.backup");
+      FileHelper.CreateBackup(_basePath + "settings.analyzer.json", _basePath, "settings.analyzer.json.backup");
 
-      FileHelper.WriteTextToFile(basePath, "settings.analyzer.json", JsonConvert.SerializeObject(asWrapper, Formatting.Indented, settings));
+      FileHelper.WriteTextToFile(_basePath, "settings.analyzer.json", JsonConvert.SerializeObject(asWrapper, Formatting.Indented, settings));
     }
 
-    public void WriteSecureSettings(string password, string basePath)
+    public void WriteSecureSettings(string password)
     {
       string passwordEncrypted = EncryptionHelper.Encrypt(password);
 
@@ -133,7 +141,7 @@ namespace Core.Main
       SecureSettingsWrapper ssWrapper = new SecureSettingsWrapper();
       ssWrapper.SecureSettings = this.SecureSettings;
 
-      FileHelper.WriteTextToFile(basePath, "settings.secure.json", JsonConvert.SerializeObject(ssWrapper, Formatting.Indented));
+      FileHelper.WriteTextToFile(_basePath, "settings.secure.json", JsonConvert.SerializeObject(ssWrapper, Formatting.Indented));
     }
   }
 }

--- a/Core/MarketAnalyzer/BaseAnalyzer.cs
+++ b/Core/MarketAnalyzer/BaseAnalyzer.cs
@@ -138,7 +138,7 @@ namespace Core.MarketAnalyzer
         string baseUrl = "https://api.github.com/repos/PTMagicians/PTMagic/releases/latest";
 
         Newtonsoft.Json.Linq.JObject jsonObject = GetSimpleJsonObjectFromURL(baseUrl, log, new (string header, string value)[] { ("User-Agent", "PTMagic.Import") });
-        
+
         if (jsonObject != null)
         {
           result = jsonObject.GetValue("tag_name").ToString();
@@ -337,55 +337,52 @@ namespace Core.MarketAnalyzer
 
           Market recentMarket = recentMarkets[recentMarketPair.Key];
 
-          if (trendMarkets.ContainsKey(recentMarketPair.Key))
+          List<string> ignoredMarkets = SystemHelper.ConvertTokenStringToList(marketTrend.IgnoredMarkets, ",");
+          if (ignoredMarkets.Contains(recentMarketPair.Value.Symbol))
           {
-            List<string> ignoredMarkets = SystemHelper.ConvertTokenStringToList(marketTrend.IgnoredMarkets, ",");
-            if (ignoredMarkets.Contains(recentMarketPair.Value.Symbol))
+            log.DoLogDebug(platform + " - Market trend '" + marketTrend.Name + "' for '" + recentMarketPair.Key + "' is ignored in this trend.");
+            continue;
+          }
+
+          List<string> allowedMarkets = SystemHelper.ConvertTokenStringToList(marketTrend.AllowedMarkets, ",");
+          if (allowedMarkets.Count > 0 && !allowedMarkets.Contains(recentMarketPair.Value.Symbol))
+          {
+            log.DoLogDebug(platform + " - Market trend '" + marketTrend.Name + "' for '" + recentMarketPair.Key + "' is not allowed in this trend.");
+            continue;
+          }
+
+          Market trendMarket = trendMarkets[recentMarketPair.Key];
+
+          if (trendMarket != null)
+          {
+            double recentMarketPrice = recentMarket.Price;
+            double trendMarketPrice = trendMarket.Price;
+
+            if (!platform.Equals("CoinMarketCap", StringComparison.InvariantCulture) && marketTrend.TrendCurrency.Equals("Fiat", StringComparison.InvariantCultureIgnoreCase))
             {
-              log.DoLogDebug(platform + " - Market trend '" + marketTrend.Name + "' for '" + recentMarketPair.Key + "' is ignored in this trend.");
-              continue;
-            }
-
-            List<string> allowedMarkets = SystemHelper.ConvertTokenStringToList(marketTrend.AllowedMarkets, ",");
-            if (allowedMarkets.Count > 0 && !allowedMarkets.Contains(recentMarketPair.Value.Symbol))
-            {
-              log.DoLogDebug(platform + " - Market trend '" + marketTrend.Name + "' for '" + recentMarketPair.Key + "' is not allowed in this trend.");
-              continue;
-            }
-
-            Market trendMarket = trendMarkets[recentMarketPair.Key];
-
-            if (trendMarket != null)
-            {
-              double recentMarketPrice = recentMarket.Price;
-              double trendMarketPrice = trendMarket.Price;
-
-              if (!platform.Equals("CoinMarketCap", StringComparison.InvariantCulture) && marketTrend.TrendCurrency.Equals("Fiat", StringComparison.InvariantCultureIgnoreCase))
+              if (recentMarket.MainCurrencyPriceUSD > 0 && trendMarket.MainCurrencyPriceUSD > 0)
               {
-                if (recentMarket.MainCurrencyPriceUSD > 0 && trendMarket.MainCurrencyPriceUSD > 0)
-                {
-                  recentMarketPrice = recentMarketPrice * recentMarket.MainCurrencyPriceUSD;
-                  trendMarketPrice = trendMarketPrice * trendMarket.MainCurrencyPriceUSD;
-                }
+                recentMarketPrice = recentMarketPrice * recentMarket.MainCurrencyPriceUSD;
+                trendMarketPrice = trendMarketPrice * trendMarket.MainCurrencyPriceUSD;
               }
-
-              double trendMarketChange = (recentMarketPrice - trendMarketPrice) / trendMarketPrice * 100;
-
-              MarketTrendChange mtc = new MarketTrendChange();
-              mtc.MarketTrendName = marketTrend.Name;
-              mtc.TrendMinutes = marketTrend.TrendMinutes;
-              mtc.TrendChange = trendMarketChange;
-              mtc.Market = recentMarket.Name;
-              mtc.LastPrice = recentMarket.Price;
-              mtc.Volume24h = recentMarket.Volume24h;
-              mtc.TrendDateTime = DateTime.UtcNow;
-
-              result.Add(mtc);
-
-              log.DoLogDebug(platform + " - Market trend '" + marketTrend.Name + "' for '" + recentMarketPair.Key + "' (Vol. " + recentMarket.Volume24h.ToString("#,#0.00") + ") is " + trendMarketChange.ToString("#,#0.00") + "% in " + SystemHelper.GetProperDurationTime(marketTrend.TrendMinutes * 60).ToLower() + ".");
-
-              marketCount++;
             }
+
+            double trendMarketChange = (recentMarketPrice - trendMarketPrice) / trendMarketPrice * 100;
+
+            MarketTrendChange mtc = new MarketTrendChange();
+            mtc.MarketTrendName = marketTrend.Name;
+            mtc.TrendMinutes = marketTrend.TrendMinutes;
+            mtc.TrendChange = trendMarketChange;
+            mtc.Market = recentMarket.Name;
+            mtc.LastPrice = recentMarket.Price;
+            mtc.Volume24h = recentMarket.Volume24h;
+            mtc.TrendDateTime = DateTime.UtcNow;
+
+            result.Add(mtc);
+
+            log.DoLogDebug(platform + " - Market trend '" + marketTrend.Name + "' for '" + recentMarketPair.Key + "' (Vol. " + recentMarket.Volume24h.ToString("#,#0.00") + ") is " + trendMarketChange.ToString("#,#0.00") + "% in " + SystemHelper.GetProperDurationTime(marketTrend.TrendMinutes * 60).ToLower() + ".");
+
+            marketCount++;
           }
         }
       }

--- a/Monitor/Pages/SettingsAnalyzer.cshtml.cs
+++ b/Monitor/Pages/SettingsAnalyzer.cshtml.cs
@@ -42,7 +42,8 @@ namespace Monitor.Pages
       SaveGlobalSettings(formKeys);
       SaveSingleMarketSettings(formKeys);
 
-      PTMagicConfiguration.WriteAnalyzerSettings(PTMagicBasePath);
+      PTMagicConfiguration.WriteAnalyzerSettings();
+      PTMagicConfiguration.RefreshSettings();
 
       NotifyHeadline = "Settings saved!";
       NotifyMessage = "Settings saved successfully to settings.analyzer.json.";

--- a/Monitor/Pages/SettingsGeneral.cshtml.cs
+++ b/Monitor/Pages/SettingsGeneral.cshtml.cs
@@ -65,6 +65,7 @@ namespace Monitor.Pages
     {
       base.Init();
 
+      // Read the new settings
       PTMagicConfiguration.GeneralSettings.Application.IsEnabled = HttpContext.Request.Form["Application_IsEnabled"].Equals("on");
       PTMagicConfiguration.GeneralSettings.Application.TestMode = HttpContext.Request.Form["Application_TestMode"].Equals("on");
       PTMagicConfiguration.GeneralSettings.Application.StartBalance = SystemHelper.TextToDouble(HttpContext.Request.Form["Application_StartBalance"], PTMagicConfiguration.GeneralSettings.Application.StartBalance, "en-US");
@@ -79,7 +80,7 @@ namespace Monitor.Pages
       PTMagicConfiguration.GeneralSettings.Application.InstanceName = HttpContext.Request.Form["Application_InstanceName"];
       PTMagicConfiguration.GeneralSettings.Application.CoinMarketCapAPIKey = HttpContext.Request.Form["Application_CoinMarketCapAPIKey"];
       PTMagicConfiguration.GeneralSettings.Application.FreeCurrencyConverterAPIKey = HttpContext.Request.Form["Application_FreeCurrencyConverterAPIKey"];
-      // 
+      
       PTMagicConfiguration.GeneralSettings.Monitor.IsPasswordProtected = HttpContext.Request.Form["Monitor_IsPasswordProtected"].Equals("on");
       PTMagicConfiguration.GeneralSettings.Monitor.OpenBrowserOnStart = HttpContext.Request.Form["Monitor_OpenBrowserOnStart"].Equals("on");
       PTMagicConfiguration.GeneralSettings.Monitor.DefaultDCAMode = HttpContext.Request.Form["Monitor_AnalyzerChart"];
@@ -105,8 +106,11 @@ namespace Monitor.Pages
       PTMagicConfiguration.GeneralSettings.Telegram.ChatId = SystemHelper.TextToInteger64(HttpContext.Request.Form["Telegram_ChatId"], PTMagicConfiguration.GeneralSettings.Telegram.ChatId);
       PTMagicConfiguration.GeneralSettings.Telegram.SilentMode = HttpContext.Request.Form["Telegram_SilentMode"].Equals("on");
 
-      PTMagicConfiguration.WriteGeneralSettings(PTMagicBasePath);
+      // Save and reload the settings
+      PTMagicConfiguration.WriteGeneralSettings();
+      PTMagicConfiguration.RefreshSettings();
 
+      // Notify
       NotifyHeadline = "Settings saved!";
       NotifyMessage = "Settings saved successfully to settings.general.json.";
       NotifyType = "success";

--- a/Monitor/Pages/SetupPassword.cshtml.cs
+++ b/Monitor/Pages/SetupPassword.cshtml.cs
@@ -26,7 +26,7 @@ namespace Monitor.Pages
       if (ModelState.IsValid)
       {
         base.PreInit();
-        PTMagicConfiguration.WriteSecureSettings(password, PTMagicBasePath);
+        PTMagicConfiguration.WriteSecureSettings(password);
 
         Response.Redirect(PTMagicConfiguration.GeneralSettings.Monitor.RootUrl + "Login");
       }


### PR DESCRIPTION
Fixes issues where:

- When saving general or analyser settings not all setting took affect until PTM was restarted, they now do

- It was possible for PTM to get stuck not being able to calculate a trend for a pair, this is now fixed