### PR TITLE
Balance Prediction & Version update

### DIFF
--- a/Monitor/Pages/SalesAnalyzer.cshtml
+++ b/Monitor/Pages/SalesAnalyzer.cshtml
@@ -122,7 +122,7 @@
     <div class="col-md-6">
       <div class="card-box">
         @{
-          double currentTotalBalance = Model.PTData.GetCurrentBalance();
+          double currentTotalBalance = Model.totalCurrentValue;
           double estimatedBalance1Month = Math.Round(currentTotalBalance * Math.Pow((1 + (avgDailyGain / 100)), 30.0), 8);
           double estimatedBalance3Months = Math.Round(currentTotalBalance * Math.Pow((1 + (avgDailyGain / 100)), 90.0), 8);
           double estimatedBalance6Months = Math.Round(currentTotalBalance * Math.Pow((1 + (avgDailyGain / 100)), 180.0), 8);

--- a/PTMagic/Program.cs
+++ b/PTMagic/Program.cs
@@ -6,7 +6,7 @@ using Core.Helper;
 using Microsoft.Extensions.DependencyInjection;
 
 
-[assembly: AssemblyVersion("2.4.6")]
+[assembly: AssemblyVersion("2.5.1")]
 [assembly: AssemblyProduct("PT Magic")]
 
 namespace PTMagic


### PR DESCRIPTION
- Changed Balance Prediction on Sales Analyzer page to use TCV rather than current balance.

- update version to 2.5.1