### PR TITLE
Fixed TCV for sales analyser and tweaked font size for tables 

### DIFF
--- a/Monitor/Pages/SalesAnalyzer.cshtml.cs
+++ b/Monitor/Pages/SalesAnalyzer.cshtml.cs
@@ -161,7 +161,7 @@ namespace Monitor.Pages
       double AvailableBalance = PTData.GetCurrentBalance();
       foreach (Core.Main.DataObjects.PTMagicData.DCALogData dcaLogEntry in PTData.DCALog)
       {
-        totalCurrentValue = totalCurrentValue + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage);
+        totalCurrentValue = totalCurrentValue + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage != 0 ? dcaLogEntry.Leverage : 1);
       }
       totalCurrentValue = totalCurrentValue + AvailableBalance;
     }

--- a/Monitor/wwwroot/assets/css/custom.css
+++ b/Monitor/wwwroot/assets/css/custom.css
@@ -132,13 +132,13 @@ a:active {
 .table {
   color      : white;
   font-family: "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size  : 12px;
+  font-size  : 11px;
 }
 
 /* If the screen size is 400px wide or less, set the font-size of <div> to 30px */
 @media screen and (max-width: 400px) {
   .table {
-    font-size: 10px;
+    font-size: 9px;
   }
 }
 


### PR DESCRIPTION
Sales analyser is broken in the current build as the leverage calculation is causing a division by 0 issue if not using leverage, this fixes it. 