### PR TITLE
Trading View & Distribution chart fixes

### DIFF
--- a/Core/Helper/SystemHelper.cs
+++ b/Core/Helper/SystemHelper.cs
@@ -536,20 +536,14 @@ namespace Core.Helper
       string result = "#";
       if (platform.Equals("TradingView"))
       {
-        result = "https://www.tradingview.com/symbols/" + market.ToUpper() + "/?exchange=" + exchange.ToUpper();
-      }
-      else if (platform.Equals("TradingViewFutures"))
-      {
-        result = "https://www.tradingview.com/chart/?symbol=";
-
-        string pairName = SystemHelper.StripBadCode(market, Constants.WhiteListMinimal);
-
-        if (pairName.StartsWith(mainMarket))
+        if (exchange.Equals("binancefutures", StringComparison.InvariantCultureIgnoreCase))
         {
-          pairName = pairName.Replace(mainMarket, "") + mainMarket;
+          result = "https://www.tradingview.com/chart/?symbol=BINANCE:" + market.ToUpper() + "PERP";
         }
-
-        result += pairName + "PERP";
+        else
+        {
+          result = "https://www.tradingview.com/?symbol=" + exchange.ToUpper() + ":" + market.ToUpper();
+        }
       }
       else
       {
@@ -614,8 +608,16 @@ namespace Core.Helper
         pairName = pairName.Replace(mainMarket, "") + mainMarket;
       }
 
-      result += pairName;
+      if (exchange.Equals("binancefutures", StringComparison.InvariantCultureIgnoreCase))
+      {
+        result = "BINANCE:" + pairName + "PERP";
+      }
+      else
+      {
+        result += pairName;
+      }
 
+      
 
       return result;
     }

--- a/Core/Helper/SystemHelper.cs
+++ b/Core/Helper/SystemHelper.cs
@@ -538,11 +538,11 @@ namespace Core.Helper
       {
         if (exchange.Equals("binancefutures", StringComparison.InvariantCultureIgnoreCase))
         {
-          result = "https://www.tradingview.com/chart/?symbol=BINANCE:" + market.ToUpper() + "PERP";
+          result = "https://uk.tradingview.com/chart/?symbol=BINANCE:" + market.ToUpper() + "PERP";
         }
         else
         {
-          result = "https://www.tradingview.com/?symbol=" + exchange.ToUpper() + ":" + market.ToUpper();
+          result = "https://uk.tradingview.com/?symbol=" + exchange.ToUpper() + ":" + market.ToUpper();
         }
       }
       else

--- a/Monitor/Pages/SalesAnalyzer.cshtml.cs
+++ b/Monitor/Pages/SalesAnalyzer.cshtml.cs
@@ -161,7 +161,12 @@ namespace Monitor.Pages
       double AvailableBalance = PTData.GetCurrentBalance();
       foreach (Core.Main.DataObjects.PTMagicData.DCALogData dcaLogEntry in PTData.DCALog)
       {
-        totalCurrentValue = totalCurrentValue + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage != 0 ? dcaLogEntry.Leverage : 1);
+        double leverage = dcaLogEntry.Leverage;
+        if (leverage == 0)
+        {
+          leverage = 1;
+        }
+        totalCurrentValue = totalCurrentValue + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / leverage);
       }
       totalCurrentValue = totalCurrentValue + AvailableBalance;
     }

--- a/Monitor/Pages/SettingsGeneral.cshtml
+++ b/Monitor/Pages/SettingsGeneral.cshtml
@@ -243,7 +243,6 @@
                   <select name="Monitor_LinkPlatform" class="form-control">
                     <option selected="@(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform.Equals("Exchange", StringComparison.InvariantCultureIgnoreCase))">Exchange</option>
                     <option selected="@(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform.Equals("TradingView", StringComparison.InvariantCultureIgnoreCase))">TradingView</option>
-                    <option selected="@(Model.PTMagicConfiguration.GeneralSettings.Monitor.LinkPlatform.Equals("TradingViewFutures", StringComparison.InvariantCultureIgnoreCase))">TradingViewFutures</option>
                   </select>
                 </div>
               </div>

--- a/Monitor/Pages/_get/DashboardBottom.cshtml.cs
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml.cs
@@ -196,15 +196,15 @@ namespace Monitor.Pages
         {
           if (sellStrategyText.Contains("PENDING"))
           {
-            PendingBalance = PendingBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage != 0 ? dcaLogEntry.Leverage : 1);
+            PendingBalance = PendingBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage);
           }
           else if (dcaLogEntry.BuyStrategies.Count > 0)
           {
-            DCABalance = DCABalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage != 0 ? dcaLogEntry.Leverage : 1);
+            DCABalance = DCABalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage);
           }
           else
           {
-            PairsBalance = PairsBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage != 0 ? dcaLogEntry.Leverage : 1);
+            PairsBalance = PairsBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage);
           }
         }
       }

--- a/Monitor/Pages/_get/DashboardBottom.cshtml.cs
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml.cs
@@ -177,34 +177,24 @@ namespace Monitor.Pages
         string sellStrategyText = Core.ProfitTrailer.StrategyHelper.GetStrategyText(Summary, dcaLogEntry.SellStrategies, dcaLogEntry.SellStrategy, isSellStrategyTrue, isTrailingSellActive);
 
         // Aggregate totals
-        if (dcaLogEntry.Leverage == 0)
+        double leverage = dcaLogEntry.Leverage;
+        if (leverage == 0)
         {
-          if (sellStrategyText.Contains("PENDING"))
-          {
-            PendingBalance = PendingBalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice);
-          }
-          else if (dcaLogEntry.BuyStrategies.Count > 0)
-          {
-            DCABalance = DCABalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice);
-          }
-          else
-          {
-            PairsBalance = PairsBalance + (dcaLogEntry.Amount * dcaLogEntry.CurrentPrice);
-          }
+          leverage = 1;
         }
         else
         {
           if (sellStrategyText.Contains("PENDING"))
           {
-            PendingBalance = PendingBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage);
+            PendingBalance = PendingBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / leverage);
           }
           else if (dcaLogEntry.BuyStrategies.Count > 0)
           {
-            DCABalance = DCABalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage);
+            DCABalance = DCABalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / leverage);
           }
           else
           {
-            PairsBalance = PairsBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / dcaLogEntry.Leverage);
+            PairsBalance = PairsBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / leverage);
           }
         }
       }

--- a/Monitor/Pages/_get/DashboardBottom.cshtml.cs
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml.cs
@@ -182,20 +182,17 @@ namespace Monitor.Pages
         {
           leverage = 1;
         }
+        if (sellStrategyText.Contains("PENDING"))
+        {
+          PendingBalance = PendingBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / leverage);
+        }
+        else if (dcaLogEntry.BuyStrategies.Count > 0)
+        {
+          DCABalance = DCABalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / leverage);
+        }
         else
         {
-          if (sellStrategyText.Contains("PENDING"))
-          {
-            PendingBalance = PendingBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / leverage);
-          }
-          else if (dcaLogEntry.BuyStrategies.Count > 0)
-          {
-            DCABalance = DCABalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / leverage);
-          }
-          else
-          {
-            PairsBalance = PairsBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / leverage);
-          }
+          PairsBalance = PairsBalance + ((dcaLogEntry.Amount * dcaLogEntry.CurrentPrice) / leverage);
         }
       }
       totalCurrentValue = PendingBalance + DCABalance + PairsBalance + AvailableBalance;

--- a/PTMagic/Program.cs
+++ b/PTMagic/Program.cs
@@ -6,7 +6,7 @@ using Core.Helper;
 using Microsoft.Extensions.DependencyInjection;
 
 
-[assembly: AssemblyVersion("2.5.4")]
+[assembly: AssemblyVersion("2.5.5")]
 [assembly: AssemblyProduct("PT Magic")]
 
 namespace PTMagic


### PR DESCRIPTION
- Fixed trading view LinkPlatform for exchanges other than BinanceFutures going to coin summary page rather than the chart
- Removed TradingViewFutures from LinkPlatform options.  Both spot and futures should now go to their correct charts when selecting "TradingView" for most exchanges
- Embedded TV charts now reference BinanceFutures coins correctly