### PR TITLE
Remove PT Path Check

### DIFF
--- a/Core/DataObjects/PTMagicData.cs
+++ b/Core/DataObjects/PTMagicData.cs
@@ -35,7 +35,6 @@ namespace Core.Main.DataObjects.PTMagicData
     public bool IsEnabled { get; set; } = true;
     public bool TestMode { get; set; } = true;
     public bool EnableBetaFeatures { get; set; } = false;
-    public string ProfitTrailerPath { get; set; }
     public string ProfitTrailerLicense { get; set; } = "";
     public string ProfitTrailerServerAPIToken { get; set; }
     public string ProfitTrailerMonitorURL { get; set; } = "http://localhost:8081/";

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -703,20 +703,11 @@ namespace Core.Main
       {
         try
         {
-          if (this.PTMagicConfiguration.GeneralSettings.Application.TestMode) this.Log.DoLogInfo("TESTMODE ENABLED - No files will be changed!");
-
-          // Check for PT Directory
-          DirectoryInfo ptRoot = new DirectoryInfo(this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath);
-          if (ptRoot.Exists)
+          if (this.PTMagicConfiguration.GeneralSettings.Application.TestMode) 
           {
-            this.Log.DoLogInfo("Profit Trailer directory found");
-            result = RunProfitTrailerSettingsAPIChecks();
+            this.Log.DoLogInfo("TESTMODE ENABLED - No files will be changed!");
           }
-          else
-          {
-            this.Log.DoLogError("Profit Trailer directory not found (" + this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + ")");
-            result = false;
-          }
+          result = RunProfitTrailerSettingsAPIChecks();
 
           // Check for CoinMarketCap API Key
           if (!String.IsNullOrEmpty(this.PTMagicConfiguration.GeneralSettings.Application.CoinMarketCapAPIKey))
@@ -1142,14 +1133,7 @@ namespace Core.Main
       }
     }
 
-    private void GetProfitTrailerPropertiesPaths(out string pairsPropertiesPath, out string dcaPropertiesPath, out string indicatorsPropertiesPath)
-    {
-      // Get current PT properties
-      pairsPropertiesPath = this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + this.PairsFileName;
-      dcaPropertiesPath = this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + this.DCAFileName;
-      indicatorsPropertiesPath = this.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath + Constants.PTPathTrading + Path.DirectorySeparatorChar + this.IndicatorsFileName;
-    }
-
+    // Get current PT properties
     private void LoadCurrentProfitTrailerProperties()
     {
       // Load current PT properties from API (Valid for PT 2.x and above)
@@ -2143,9 +2127,6 @@ namespace Core.Main
     private void SaveProfitTrailerProperties()
     {
       // Get current PT properties
-      string pairsPropertiesPath, dcaPropertiesPath, indicatorsPropertiesPath;
-      GetProfitTrailerPropertiesPaths(out pairsPropertiesPath, out dcaPropertiesPath, out indicatorsPropertiesPath);
-
       if (this.GlobalSettingWritten || this.SingleMarketSettingChanged)
       {
         // Save current PT properties to API (Valid for PT 2.x and above)

--- a/Core/Main/PTMagicConfiguration.cs
+++ b/Core/Main/PTMagicConfiguration.cs
@@ -47,11 +47,6 @@ namespace Core.Main
       AnalyzerSettingsWrapper asw = JsonConvert.DeserializeObject<AnalyzerSettingsWrapper>(File.ReadAllText(basePath + "settings.analyzer.json"));
       _analyzerSettings = asw.AnalyzerSettings;
 
-      if (!_generalSettings.Application.ProfitTrailerPath.EndsWith(Path.DirectorySeparatorChar))
-      {
-        _generalSettings.Application.ProfitTrailerPath += Path.DirectorySeparatorChar;
-      }
-
       if (!_generalSettings.Application.ProfitTrailerMonitorURL.EndsWith("/"))
       {
         _generalSettings.Application.ProfitTrailerMonitorURL += "/";

--- a/Monitor/Pages/SettingsGeneral.cshtml
+++ b/Monitor/Pages/SettingsGeneral.cshtml
@@ -68,12 +68,6 @@
                 </div>
               </div>
 
-              <div class="form-group row">
-                <label class="col-md-4 col-form-label">Profit Trailer Path <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Path to your Profit Trailer main directory."></i></label>
-                <div class="col-md-8">
-                  @Model.PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerPath
-                </div>
-              </div>
 
               <div class="form-group row">
                 <label class="col-md-4 col-form-label">Profit Trailer License <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Your Profit Trailer license key (needed to change your settings for PT 2.0 and above)"></i></label>

--- a/PTMagic/_defaults/_default_settings_PT_2.x/settings.general.json
+++ b/PTMagic/_defaults/_default_settings_PT_2.x/settings.general.json
@@ -3,7 +3,6 @@
     "Application": {
       "IsEnabled": true, // Enables the PTMagic bot (needs restart to take effect)
       "TestMode": false, // If TestMode is active, no properties files will be changed
-      "ProfitTrailerPath": "YOUR PROFIT TRAILER PATH", // Path to your Profit Trailer main directory (use double backslashes for windows like C:\\ProfitTrailer\\)
       "ProfitTrailerLicense": "YOUR PROFIT TRAILER LICENSE KEY", // Your Profit Trailer license key (needed to change your settings for PT 2.0 and above)
       "ProfitTrailerServerAPIToken": "", //Your Profit Trailer Server API Token
       "ProfitTrailerMonitorURL": "http://localhost:8081/", // The URL to your profit trailer monitor (needed to change your settings for PT 2.0 and above)

--- a/_Development/DevSettings/settings.general.json
+++ b/_Development/DevSettings/settings.general.json
@@ -3,7 +3,6 @@
     "Application": {
       "IsEnabled": true, // Enables the PTMagic bot (needs restart to take effect)
       "TestMode": false, // If TestMode is active, no properties files will be changed
-      "ProfitTrailerPath": "YOUR PROFIT TRAILER PATH", // Path to your Profit Trailer main directory (use double backslashes for windows like C:\\ProfitTrailer\\)
       "ProfitTrailerLicense": "YOUR PROFIT TRAILER LICENSE KEY", // Your Profit Trailer license key (needed to change your settings for PT 2.0 and above)
       "ProfitTrailerServerAPIToken": "", //Your Profit Trailer Server API Token
       "ProfitTrailerMonitorURL": "http://localhost:8081/", // The URL to your profit trailer monitor (needed to change your settings for PT 2.0 and above)


### PR DESCRIPTION
- Removed the check for a local Profit Trailer path, and all references
- This will allow the use of PTM on a machine other than the one hosting Profit Trailer (eg., PT VPN subscribers)