### PR TITLE
API Mask & unlock settings

### DIFF
--- a/Core/Main/PTMagicConfiguration.cs
+++ b/Core/Main/PTMagicConfiguration.cs
@@ -84,14 +84,17 @@ namespace Core.Main
 
       if (!this.GeneralSettings.Application.ProfitTrailerServerAPIToken.Equals(""))
       {
-        result = this.GeneralSettings.Application.ProfitTrailerServerAPIToken.Substring(0, 4);
-
-        for (int i = 1; i < this.GeneralSettings.Application.ProfitTrailerServerAPIToken.Length - 8; i++)
+        int tokenLength = this.GeneralSettings.Application.ProfitTrailerServerAPIToken.Length;
+        if (tokenLength == 1)
+        {
+          result = "*";
+        }
+        else
+        result = this.GeneralSettings.Application.ProfitTrailerServerAPIToken.Substring(0, 1);
+        for (int i = 1; i < this.GeneralSettings.Application.ProfitTrailerServerAPIToken.Length; i++)
         {
           result += "*";
         }
-
-        result += this.GeneralSettings.Application.ProfitTrailerServerAPIToken.Substring(this.GeneralSettings.Application.ProfitTrailerServerAPIToken.Length - 4);
       }
 
       return result;

--- a/Monitor/Pages/Login.cshtml.cs
+++ b/Monitor/Pages/Login.cshtml.cs
@@ -30,7 +30,8 @@ namespace Monitor.Pages
       if (encryptedPassword.Equals(PTMagicConfiguration.SecureSettings.MonitorPassword))
       {
         HttpContext.Session.SetString("LoggedIn" + PTMagicConfiguration.GeneralSettings.Monitor.Port.ToString(), DateTime.UtcNow.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff'Z'"));
-
+        PTMagicConfiguration.GeneralSettings.Monitor.IsPasswordProtected = true;
+        PTMagicConfiguration.WriteGeneralSettings();
         if (cbRememberMe != null)
         {
           if (cbRememberMe.Equals("on", StringComparison.InvariantCultureIgnoreCase))

--- a/Monitor/Pages/SettingsGeneral.cshtml
+++ b/Monitor/Pages/SettingsGeneral.cshtml
@@ -86,7 +86,7 @@
               <div class="form-group row">
                 <label class="col-md-4 col-form-label">Profit Trailer Server API Token <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="The API token needed to communicate with Profit Trailer - set in Profit Trailer Server Settings"></i></label>
                 <div class="col-md-8">
-                  <input type="text" class="form-control" name="Application_ProfitTrailerServerAPIToken" value="@Model.PTMagicConfiguration.GetProfitTrailerServerAPITokenMasked()">
+                  @Model.PTMagicConfiguration.GetProfitTrailerServerAPITokenMasked()
                 </div>
               </div>
 

--- a/Monitor/Pages/SettingsGeneral.cshtml.cs
+++ b/Monitor/Pages/SettingsGeneral.cshtml.cs
@@ -71,7 +71,6 @@ namespace Monitor.Pages
       PTMagicConfiguration.GeneralSettings.Application.StartBalance = SystemHelper.TextToDouble(HttpContext.Request.Form["Application_StartBalance"], PTMagicConfiguration.GeneralSettings.Application.StartBalance, "en-US");
       PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerDefaultSettingName = HttpContext.Request.Form["Application_ProfitTrailerDefaultSettingName"];
 
-      PTMagicConfiguration.GeneralSettings.Application.ProfitTrailerServerAPIToken = HttpContext.Request.Form["Application_ProfitTrailerServerAPIToken"];
       PTMagicConfiguration.GeneralSettings.Application.TimezoneOffset = HttpContext.Request.Form["Application_TimezoneOffset"];
       PTMagicConfiguration.GeneralSettings.Application.MainFiatCurrency = HttpContext.Request.Form["Application_MainFiatCurrency"];
       

--- a/Monitor/Pages/_Layout.cshtml
+++ b/Monitor/Pages/_Layout.cshtml
@@ -107,7 +107,7 @@
               </li>
             } else {
               <li>
-                <a data-toggle="tooltip" data-placement="top" title="Settings menu is only accessible when you protect your monitor with a password!"><i class="fa fa-lock text-danger"></i> <span> Settings</span></a>
+                <a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)Login"  data-toggle="tooltip" data-placement="top" title="Settings menu is only accessible when you protect your monitor with a password!"><i class="fa fa-lock text-danger"></i> <span> Settings</span></a>
               </li>
             }
 

--- a/Monitor/_Internal/BasePageModelSecure.cs
+++ b/Monitor/_Internal/BasePageModelSecure.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using System.Net;
+using System;
 using Microsoft.AspNetCore.Http;
 using Core.Main;
 using Core.Helper;
@@ -27,7 +28,8 @@ namespace Monitor._Internal
       // Security check
       if (!IsLoggedIn(this.HttpContext))
       {
-        HttpContext.Response.Redirect(PTMagicConfiguration.GeneralSettings.Monitor.RootUrl + _redirectUrl);
+        this.HttpContext.Response.Clear();
+        this.HttpContext.Response.Redirect(PTMagicConfiguration.GeneralSettings.Monitor.RootUrl + _redirectUrl);        
       }
     }
 


### PR DESCRIPTION
- The changes to allow the user to edit the masked API token won't work. If settings are saved (due to editing some other setting), the masked version of the API token is written to general.settings, which of course breaks the API access to PT. I reverted this to @JackTerok's first version, just showing an un-editable value like the license.

- Altered the masking method a bit, to encompass all possible lengths. PT has no minimum length for an API token, so the method has to account for a possible length of 1.  As written, anything under 4 characters would throw an error.

- When password is disabled and the Settings page is locked on the menu, users can now click "Settings" to go to the Login page.

- Logging on now changes the general.settings value for "PasswordEnabled" to true. This allows users to re-gain access to the Settings page again if PasswordEnabled was turned off, without having to edit the general.settings file directly.