### PR TITLE
Ignored/Allowed in SMS && BinanceFutures Quarterly Contracts

### DIFF
--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -1518,7 +1518,7 @@ namespace Core.Main
 
             // Check ignore markets
             List<string> ignoredMarkets = SystemHelper.ConvertTokenStringToList(marketSetting.IgnoredMarkets, ",");
-            if (ignoredMarkets.Contains(marketPair))
+            if (ignoredMarkets.Any(marketPair.Contains))
             {
               this.Log.DoLogDebug("'" + marketPair + "' - Is ignored in '" + marketSetting.SettingName + "'.");
               continue;
@@ -1526,7 +1526,7 @@ namespace Core.Main
 
             // Check allowed markets
             List<string> allowedMarkets = SystemHelper.ConvertTokenStringToList(marketSetting.AllowedMarkets, ",");
-            if (allowedMarkets.Count > 0 && !allowedMarkets.Contains(marketPair))
+            if (allowedMarkets.Count > 0 && !allowedMarkets.Any(marketPair.Contains))
             {
               this.Log.DoLogDebug("'" + marketPair + "' - Is not allowed in '" + marketSetting.SettingName + "'.");
               continue;

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -903,6 +903,30 @@ namespace Core.Main
               // Check for single market trend triggers
               this.ApplySingleMarketSettings();
 
+              // Ignore quarterly futures
+              if (this.PTMagicConfiguration.GeneralSettings.Application.Exchange.Equals("BinanceFutures", StringComparison.InvariantCultureIgnoreCase))
+              {
+                var quarterlyFuturesLines = new Dictionary<string, string>();
+
+                // Find all quarterly futures pairs
+                var results = this.MarketList.FindAll(m => m.Contains("_", StringComparison.InvariantCultureIgnoreCase));
+
+                // Create the settings lines to disable trading
+                if (results.Count > 0)
+                {
+                  this.PairsLines.AddRange(new string[] {
+                    "",
+                    "# BinanceFutures Quarterly Contracts - Ignore list:",
+                    "###################################################"
+                  });
+
+                  foreach (var marketPair in results)
+                  {
+                    this.PairsLines.Add(String.Format("{0}_trading_enabled = false", marketPair));
+                  }
+                }
+              }
+
               // Save new properties to Profit Trailer
               this.SaveProfitTrailerProperties();
 

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -906,8 +906,6 @@ namespace Core.Main
               // Ignore quarterly futures
               if (this.PTMagicConfiguration.GeneralSettings.Application.Exchange.Equals("BinanceFutures", StringComparison.InvariantCultureIgnoreCase))
               {
-                var quarterlyFuturesLines = new Dictionary<string, string>();
-
                 // Find all quarterly futures pairs
                 var results = this.MarketList.FindAll(m => m.Contains("_", StringComparison.InvariantCultureIgnoreCase));
 

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -1526,7 +1526,7 @@ namespace Core.Main
 
             // Check allowed markets
             List<string> allowedMarkets = SystemHelper.ConvertTokenStringToList(marketSetting.AllowedMarkets, ",");
-            if (allowedMarkets.Count > 0 && !allowedMarkets.Any(marketPair.Contains))
+            if (allowedMarkets.Count > 0 && !allowedMarkets.Any(am => marketPair.StartsWith(am, StringComparison.InvariantCultureIgnoreCase)))
             {
               this.Log.DoLogDebug("'" + marketPair + "' - Is not allowed in '" + marketSetting.SettingName + "'.");
               continue;
@@ -1534,7 +1534,7 @@ namespace Core.Main
 
             // Check ignore global settings
             List<string> ignoredGlobalSettings = SystemHelper.ConvertTokenStringToList(marketSetting.IgnoredGlobalSettings, ",");
-            if (ignoredGlobalSettings.Contains(this.ActiveSettingName))
+            if (ignoredMarkets.Any(im => marketPair.StartsWith(im, StringComparison.InvariantCultureIgnoreCase)))
             {
               this.Log.DoLogDebug("'" + marketPair + "' - '" + this.ActiveSettingName + "' - Is ignored in '" + marketSetting.SettingName + "'.");
               continue;

--- a/Core/MarketAnalyzer/BinanceFutures.cs
+++ b/Core/MarketAnalyzer/BinanceFutures.cs
@@ -74,9 +74,7 @@ namespace Core.MarketAnalyzer
               //New variables for filtering out bad markets
               float marketLastPrice = currencyTicker["lastPrice"].ToObject<float>();
               float marketVolume = currencyTicker["volume"].ToObject<float>();
-              if (marketName.EndsWith(mainMarket, StringComparison.InvariantCultureIgnoreCase))
-              {
-                if (marketLastPrice > 0 && marketVolume > 0)
+              if (marketLastPrice > 0 && marketVolume > 0)
                 {
 
                   // Set last values in case any error occurs
@@ -100,7 +98,6 @@ namespace Core.MarketAnalyzer
                   //Let the user know that the problem market was ignored.
                   log.DoLogInfo("BinanceFutures - Ignoring bad market data for " + marketName);
                 }
-              }
             }
 
             BinanceFutures.CheckFirstSeenDates(markets, ref marketInfos, systemConfiguration, log);


### PR DESCRIPTION
Changed the logic for the SMS parameters IgnoredMarkets & AllowedMarkets -- they now allow a partial string of the market to match for a trigger.

For example, if you want to ignore BTCUSDT you now only need to specify BTC.

The main reason for this was a significant problem trading Binance Futures that the Dev was unwilling to address.  See Issue #287 
All BTC quarterly futures positions (such as BTCUSDT_210326 and BTCUSDT_210625) can now be easily filtered by creating an SMS with "AllowedMarkets ": "BTC".   Even better, ALL current and future quarterly futures can be summarily ignored by filtering for "_" (underscore) since these are the only markets that have an underscore in their name.

However, users should be aware that any subset of a pair will cause a match.  For example, "AllowedMarkets": "ZUS" would match for  "ZUSUSDT," "CRZUSDT," "XTZUSDT," and "BLZUSDT."    To avoid ambiguity, most users should probably continue to specify the complete pair, "ZUSUSDT."