### PR TITLE
Bug Fixes

### DIFF
--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -716,7 +716,7 @@ namespace Core.Main
           }
           else
           {
-            this.Log.DoLogInfo("No CoinMarketCap API KEY specified! You can't use CoinMarketCap in your settings.analyzer.json");
+            this.Log.DoLogInfo("No CoinMarketCap API KEY specified! That's ok, but you can't use CoinMarketCap in your settings.analyzer.json");
           }
 
           // Check for CurrencyConverterApi Key
@@ -726,7 +726,7 @@ namespace Core.Main
           }
           else
           {
-            this.Log.DoLogInfo("No FreeCurrencyConverterApi KEY specified, you can only use USD; apply for a key at: https://freecurrencyrates.com/en");
+            this.Log.DoLogInfo("No FreeCurrencyConverterApi KEY specified. That's ok!  But you can only use USD; apply for a key at: https://freecurrencyrates.com/en");
           }
         }
         catch (System.NullReferenceException)
@@ -1234,7 +1234,7 @@ namespace Core.Main
       }
       else
       {
-        this.Log.DoLogInfo("No CMC API-Key specified. No CMC Data will be pulled");
+        this.Log.DoLogInfo("No CMC API-Key specified. That's OK, but no CMC Data can be pulled.");
       }
 
       if (this.PTMagicConfiguration.GeneralSettings.Application.Exchange.Equals("Bittrex", StringComparison.InvariantCultureIgnoreCase))

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -1525,12 +1525,22 @@ namespace Core.Main
 
         int marketPairProcess = 1;
         Dictionary<string, List<string>> matchedMarketTriggers = new Dictionary<string, List<string>>();
+        string mainMarket = this.LastRuntimeSummary.MainMarket;
 
         // Loop through markets
         foreach (string marketPair in this.MarketList)
         {
           this.Log.DoLogDebug("'" + marketPair + "' - Checking triggers (" + marketPairProcess.ToString() + "/" + this.MarketList.Count.ToString() + ")...");
-
+          string market = marketPair.Replace(mainMarket, "");
+          switch (this.PTMagicConfiguration.GeneralSettings.Application.Exchange.ToLower())
+            {
+              case "bittrex":
+              market = market.Replace("-", "");
+              break;
+              case "poloniex":
+              market = market.Replace("-", "");
+              break;
+            }
           bool stopTriggers = false;
 
           // Loop through single market settings
@@ -1539,16 +1549,42 @@ namespace Core.Main
             List<string> matchedSingleMarketTriggers = new List<string>();
 
             // Check ignore markets
-            List<string> ignoredMarkets = SystemHelper.ConvertTokenStringToList(marketSetting.IgnoredMarkets, ",");
-            if (ignoredMarkets.Any(im => marketPair.StartsWith(im, StringComparison.InvariantCultureIgnoreCase)))
+            
+            // Strip main markets from list, if exists
+            string ignored = marketSetting.IgnoredMarkets.ToUpper();
+            ignored = ignored.Replace(mainMarket, "");
+            switch (this.PTMagicConfiguration.GeneralSettings.Application.Exchange.ToLower())
+            {
+              case "bittrex":
+              ignored = ignored.Replace("-", "");
+              break;
+              case "poloniex":
+              ignored = ignored.Replace("_", "");
+              break;
+            }
+            List<string> ignoredMarkets = SystemHelper.ConvertTokenStringToList(ignored, ",");
+            if (ignoredMarkets.Contains(market))
             {
               this.Log.DoLogDebug("'" + marketPair + "' - Is ignored in '" + marketSetting.SettingName + "'.");
               continue;
             }
 
             // Check allowed markets
-            List<string> allowedMarkets = SystemHelper.ConvertTokenStringToList(marketSetting.AllowedMarkets, ",");
-            if (allowedMarkets.Count > 0 && !allowedMarkets.Any(am => marketPair.StartsWith(am, StringComparison.InvariantCultureIgnoreCase)))
+            
+            // Strip main markets from list, if exists
+            string allowed = marketSetting.IgnoredMarkets.ToUpper();
+            allowed = allowed.Replace(mainMarket, "");
+            switch (this.PTMagicConfiguration.GeneralSettings.Application.Exchange.ToLower())
+            {
+              case "bittrex":
+              allowed = allowed.Replace("-", "");
+              break;
+              case "poloniex":
+              allowed = allowed.Replace("_", "");
+              break;
+            }
+            List<string> allowedMarkets = SystemHelper.ConvertTokenStringToList(allowed, ",");
+            if (allowedMarkets.Count > 0 && !allowedMarkets.Contains(market))
             {
               this.Log.DoLogDebug("'" + marketPair + "' - Is not allowed in '" + marketSetting.SettingName + "'.");
               continue;

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -1572,7 +1572,7 @@ namespace Core.Main
             // Check allowed markets
             
             // Strip main markets from list, if exists
-            string allowed = marketSetting.IgnoredMarkets.ToUpper();
+            string allowed = marketSetting.AllowedMarkets.ToUpper();
             allowed = allowed.Replace(mainMarket, "");
             switch (this.PTMagicConfiguration.GeneralSettings.Application.Exchange.ToLower())
             {

--- a/Core/MarketAnalyzer/BaseAnalyzer.cs
+++ b/Core/MarketAnalyzer/BaseAnalyzer.cs
@@ -308,16 +308,51 @@ namespace Core.MarketAnalyzer
           }
 
           Market recentMarket;
+          string market = recentMarketPair.Value.Symbol.Replace(mainMarket, "");
+          string exchange = systemConfiguration.GeneralSettings.Application.Exchange.ToLower();
+          switch (exchange)
+            {
+              case "bittrex":
+              market = market.Replace("-", "");
+              break;
+              case "poloniex":
+              market = market.Replace("-", "");
+              break;
+            }
           if (recentMarkets.TryGetValue(recentMarketPair.Key, out recentMarket))
           {
-            List<string> ignoredMarkets = SystemHelper.ConvertTokenStringToList(marketTrend.IgnoredMarkets, ",");
-            if (ignoredMarkets.Any(im => recentMarketPair.Value.Symbol.StartsWith(im, StringComparison.InvariantCultureIgnoreCase)))
+            // Strip main markets from lists, if exists
+            string ignored = marketTrend.IgnoredMarkets.ToUpper();
+            ignored = ignored.Replace(mainMarket, "");
+            switch (exchange)
+            {
+              case "bittrex":
+              ignored = ignored.Replace("-", "");
+              break;
+              case "poloniex":
+              ignored = ignored.Replace("_", "");
+              break;
+            }
+            List<string> ignoredMarkets = SystemHelper.ConvertTokenStringToList(ignored, ",");
+            if (ignoredMarkets.Contains(market))
             {
               log.DoLogDebug(platform + " - Market trend '" + marketTrend.Name + "' for '" + recentMarketPair.Key + "' is ignored in this trend.");
               continue;
             }
-            List<string> allowedMarkets = SystemHelper.ConvertTokenStringToList(marketTrend.AllowedMarkets, ",");
-            if (allowedMarkets.Count > 0 && !allowedMarkets.Any(am => recentMarketPair.Value.Symbol.StartsWith(am, StringComparison.InvariantCultureIgnoreCase)))
+            // Strip main markets from lists, if exists
+            string allowed = marketTrend.AllowedMarkets.ToUpper();
+            allowed = allowed.Replace(mainMarket, "");
+            switch (exchange)
+            {
+              case "bittrex":
+              allowed = allowed.Replace("-", "");
+              break;
+              case "poloniex":
+              allowed = allowed.Replace("_", "");
+              break;
+            }
+            List<string> allowedMarkets = SystemHelper.ConvertTokenStringToList(allowed, ",");
+            if (allowedMarkets.Count > 0 && !allowedMarkets.Contains(market))
             {
               log.DoLogDebug(platform + " - Market trend '" + marketTrend.Name + "' for '" + recentMarketPair.Key + "' is not allowed in this trend.");
               continue;

--- a/Core/MarketAnalyzer/Binance.cs
+++ b/Core/MarketAnalyzer/Binance.cs
@@ -364,12 +364,12 @@ namespace Core.MarketAnalyzer
         ConcurrentDictionary<string, List<MarketTick>> marketTicks = new ConcurrentDictionary<string, List<MarketTick>>();
 
         int ParallelThrottle = 4;
-        if (systemConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours > 200)
+        if (systemConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours > 50)
         {
           ParallelThrottle = 2;
           log.DoLogInfo("----------------------------------------------------------------------------");
-          log.DoLogInfo("StoreDataMaxHours is greater than 200.  Historical data requests will be");
-          log.DoLogInfo("throttled to avoid exceeding exchange data request limits.  This initial ");
+          log.DoLogInfo("StoreDataMaxHours is greater than 50.  Historical data requests will be");
+          log.DoLogInfo("throttled to avoid exceeding exchange request limits.  This initial ");
           log.DoLogInfo("run could take more than 30 minutes.  Please go outside for a walk...");
           log.DoLogInfo("----------------------------------------------------------------------------");
         }

--- a/Core/MarketAnalyzer/BinanceFutures.cs
+++ b/Core/MarketAnalyzer/BinanceFutures.cs
@@ -361,11 +361,11 @@ namespace Core.MarketAnalyzer
         ConcurrentDictionary<string, List<MarketTick>> marketTicks = new ConcurrentDictionary<string, List<MarketTick>>();
 
         int ParallelThrottle = 4;
-        if (systemConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours > 200)
+        if (systemConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours > 50)
         {
           ParallelThrottle = 2;
           log.DoLogInfo("----------------------------------------------------------------------------");
-          log.DoLogInfo("StoreDataMaxHours is greater than 200.  Historical data requests will be");
+          log.DoLogInfo("StoreDataMaxHours is greater than 50.  Historical data requests will be");
           log.DoLogInfo("throttled to avoid exceeding exchange data request limits.  This initial ");
           log.DoLogInfo("run could take more than 30 minutes.  Please go outside for a walk...");
           log.DoLogInfo("----------------------------------------------------------------------------");

--- a/Monitor/Pages/MarketAnalyzer.cshtml
+++ b/Monitor/Pages/MarketAnalyzer.cshtml
@@ -183,14 +183,15 @@ else
               <tr>
                 <td>@Core.Helper.SystemHelper.SplitCamelCase(marketTrend.Name)</td>
                 <td class="text-right">@marketCountString</td>
-                <td class="text-right">@Core.Helper.SystemHelper.GetProperDurationTime(marketTrend.TrendMinutes * 60, false)</td> @if (marketTrend.TrendThreshold == 0)
-                {
-                  <td class="text-right">--</td>
-                }
-                else
-                {
-                  <td class="text-right">@marketTrend.TrendThreshold</td>
-                }
+                <td class="text-right">@Core.Helper.SystemHelper.GetProperDurationTime(marketTrend.TrendMinutes * 60, false)</td> 
+                  @if (marketTrend.TrendThreshold == 0)
+                  {
+                    <td class="text-right">--</td>
+                  }
+                  else
+                  {
+                    <td class="text-right">@marketTrend.TrendThreshold</td>
+                  }
                 <td class="text-right text-autocolor">@trendChangeOutput%</td>
               </tr>
             }
@@ -275,18 +276,18 @@ else
               <td class="text-right">@mps.LatestPrice.ToString("#,#0.00000000", new System.Globalization.CultureInfo("en-US")) @Model.Summary.MainMarket</td>
               <td class="text-right">@Math.Round(mps.Latest24hVolume, 0).ToString("#,#0", new System.Globalization.CultureInfo("en-US")) @Model.Summary.MainMarket</td>
               @foreach (Core.Main.DataObjects.PTMagicData.MarketTrend marketTrend in marketTrends) {
-                if (mps.MarketTrendChanges.ContainsKey(marketTrend.Name)) {
+                if (mps.MarketTrendChanges.ContainsKey(marketTrend.Name)) 
+                {
                   marketTrendsDisplayed++;
                   string trendChangeOutput = mps.MarketTrendChanges[marketTrend.Name].ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"));
-                  if ((mps.MarketTrendChanges[marketTrend.Name] > marketTrend.TrendThreshold) || (mps.MarketTrendChanges[marketTrend.Name] > marketTrend.TrendThreshold) )
-                  {
-                    <td class="text-right text-autocolor-saw"><i class="fa fa-ban text-muted" data-toggle="tooltip" data-placement="top" title="This coin has been excluded from the Market Trend Averages for this timeframe due to your Threshold setting."></i>&nbsp; @trendChangeOutput%</td>
-                  }
-                  else
-                  {
-                    <td class="text-right text-autocolor-saw">@trendChangeOutput%</td>
-                  }
-                 
+                  if  (marketTrend.TrendThreshold != 0 && Math.Abs(mps.MarketTrendChanges[marketTrend.Name]) > marketTrend.TrendThreshold)
+                    {
+                      <td class="text-right text-autocolor-saw"><i class="fa fa-ban text-muted" data-toggle="tooltip" data-placement="top" title="This coin has been excluded from the Market Trend Averages for this timeframe due to your Threshold setting."></i>&nbsp; @trendChangeOutput%</td>
+                    }
+                    else
+                    {
+                      <td class="text-right text-autocolor-saw">@trendChangeOutput%</td>
+                    }
                 }
               }
               @for (int i = 0; i < marketTrends.Count - marketTrendsDisplayed; i++) {

--- a/PTMagic/Program.cs
+++ b/PTMagic/Program.cs
@@ -6,7 +6,7 @@ using Core.Helper;
 using Microsoft.Extensions.DependencyInjection;
 
 
-[assembly: AssemblyVersion("2.5.8")]
+[assembly: AssemblyVersion("2.5.9")]
 [assembly: AssemblyProduct("PT Magic")]
 
 namespace PTMagic


### PR DESCRIPTION
- Fixed an error that caused the Threshold warning symbol to show incorrectly on the Market Analyzer page when Threshold was missing or set to zero.

- Adjusted the Binance data request to throttle for StoreDataMaxHours values above 50, to avoid API bans.

- Changed the missing CMC and FreeCurrencyRates log message to make it clearer they are optional.