### PR TITLE
shorting calculations

### DIFF
--- a/Core/DataObjects/ProfitTrailerData.cs
+++ b/Core/DataObjects/ProfitTrailerData.cs
@@ -355,15 +355,9 @@ namespace Core.Main.DataObjects
         sellLogData.ProfitPercent = rsld.profit;
         sellLogData.SoldPrice = rsld.currentPrice;
         sellLogData.AverageBuyPrice = rsld.avgPrice;
-        sellLogData.TotalCost = sellLogData.SoldAmount * sellLogData.AverageBuyPrice;
+        sellLogData.TotalCost = rsld.totalCost;
+        sellLogData.Profit = rsld.profitCurrency;
 
-        // check if bot is a shortbot via PT API.  Losses on short bot currently showing as gains. Issue #195
-        // code removed
-
-        double soldValueRaw = (sellLogData.SoldAmount * sellLogData.SoldPrice);
-        double soldValueAfterFees = soldValueRaw - (soldValueRaw * ((double)rsld.fee / 100));
-        sellLogData.SoldValue = soldValueAfterFees;
-        sellLogData.Profit = Math.Round(sellLogData.SoldValue - sellLogData.TotalCost, 8);
 
         //Convert Unix Timestamp to Datetime
         System.DateTime dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);

--- a/Monitor/Pages/SalesAnalyzer.cshtml
+++ b/Monitor/Pages/SalesAnalyzer.cshtml
@@ -62,14 +62,7 @@
         <h4 class="m-t-0 header-title">Sales Analysis</h4>
         @{
           double totalProfit = 0;
-          if (Model.PTData.Properties.Shorting)
-          {
-            totalProfit = Model.PTData.SellLog.Sum(s => s.Profit * (-1));
-          }
-          else
-          {
-            totalProfit = Model.PTData.SellLog.Sum(s => s.Profit);
-          }
+          totalProfit = Model.PTData.SellLog.Sum(s => s.Profit);
           double totalProfitFiat = Math.Round(totalProfit * Model.Summary.MainMarketPrice, 2);
           double percentGain = Math.Round(totalProfit / Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance * 100, 2);
           double avgDailyGain = Model.DailyGains.Values.Average(dg => dg);
@@ -205,14 +198,7 @@
             @for (DateTime salesDate = Model.DateTimeNow.DateTime.Date; salesDate >= Model.DateTimeNow.DateTime.AddDays(-Model.PTMagicConfiguration.GeneralSettings.Monitor.MaxDailySummaries) && salesDate >= Model.MinSellLogDate; salesDate = salesDate.AddDays(-1)) {
               List<Core.Main.DataObjects.PTMagicData.SellLogData> salesDateSales = Model.PTData.SellLog.FindAll(sl => sl.SoldDate.Date == salesDate);
               double salesDateProfit = 0;
-              if (Model.PTData.Properties.Shorting)
-              {
-                salesDateProfit = salesDateSales.Sum(sl => sl.Profit * (-1));
-              }
-              else
-              {
-                salesDateProfit = salesDateSales.Sum(sl => sl.Profit);
-              }
+              salesDateProfit = salesDateSales.Sum(sl => sl.Profit);
               double salesDateProfitFiat = Math.Round(salesDateProfit * Model.Summary.MainMarketPrice, 2);
               double salesDateStartBalance = Model.PTData.GetSnapshotBalance(salesDate);
               double salesDateGain = Math.Round(salesDateProfit / salesDateStartBalance * 100, 2);
@@ -252,14 +238,7 @@
             @for (DateTime salesMonthDate = salesMonthStartDate.Date; salesMonthDate >= Model.DateTimeNow.DateTime.AddMonths(-Model.PTMagicConfiguration.GeneralSettings.Monitor.MaxMonthlySummaries) && salesMonthDate >= minSellLogMonthDate; salesMonthDate = salesMonthDate.AddMonths(-1)) {
               List<Core.Main.DataObjects.PTMagicData.SellLogData> salesMonthSales = Model.PTData.SellLog.FindAll(sl => sl.SoldDate.Date.Month == salesMonthDate.Month && sl.SoldDate.Date.Year == salesMonthDate.Year);
               double salesDateProfit = 0;
-              if (Model.PTData.Properties.Shorting)
-              {
-                salesDateProfit = salesMonthSales.Sum(sl => sl.Profit * (-1));
-              }
-              else 
-              {
-                salesDateProfit = salesMonthSales.Sum(sl => sl.Profit);
-              }
+              salesDateProfit = salesMonthSales.Sum(sl => sl.Profit);
               double salesDateProfitFiat = Math.Round(salesDateProfit * Model.Summary.MainMarketPrice, 2);
               double salesDateStartBalance = Model.PTData.GetSnapshotBalance(salesMonthDate);
               double salesDateGain = Math.Round(salesDateProfit / salesDateStartBalance * 100, 2);
@@ -272,14 +251,7 @@
                   days++;
                   List<Core.Main.DataObjects.PTMagicData.SellLogData> monthDaySales = Model.PTData.SellLog.FindAll(sl => sl.SoldDate.Date == monthDay.Date);
                   double monthDayProfit = 0;
-                  if (Model.PTData.Properties.Shorting)
-                  {
-                    monthDayProfit = monthDaySales.Sum(sl => sl.Profit * (-1));
-                  }
-                  else
-                  {
-                    monthDayProfit = monthDaySales.Sum(sl => sl.Profit);
-                  }
+                  monthDayProfit = monthDaySales.Sum(sl => sl.Profit);
                   double monthDayStartBalance = Model.PTData.GetSnapshotBalance(monthDay);
                   monthDailyProfit += Math.Round(monthDayProfit / monthDayStartBalance * 100, 2);
                 }
@@ -319,10 +291,6 @@
           <tbody>
             @{
               var topMarkets = Model.PTData.SellLog.GroupBy(m => m.Market).Select(mg => mg.Sum(m => m.Profit));
-              if (Model.PTData.Properties.Shorting)
-              {
-                topMarkets = Model.PTData.SellLog.GroupBy(m => m.Market).Select(mg => mg.Sum(m => m.Profit) * (-1));
-              }
               int marketRank = 0;
             }
             @foreach (KeyValuePair<string, double> marketData in Model.TopMarkets) {

--- a/Monitor/Pages/SalesAnalyzer.cshtml.cs
+++ b/Monitor/Pages/SalesAnalyzer.cshtml.cs
@@ -46,14 +46,7 @@ namespace Monitor.Pages
       foreach (var market in markets)
       {
         double totalProfit = 0;
-        if (PTData.Properties.Shorting)
-        {
-          totalProfit = PTData.SellLog.FindAll(m => m.Market == market.Key).Sum(m => m.Profit * (-1));
-        }
-        else
-        {
-          totalProfit = PTData.SellLog.FindAll(m => m.Market == market.Key).Sum(m => m.Profit);
-        }
+        totalProfit = PTData.SellLog.FindAll(m => m.Market == market.Key).Sum(m => m.Profit);
         topMarketsDic.Add(market.Key, totalProfit);
       }
       TopMarkets = new SortedDictionary<string, double>(topMarketsDic).OrderByDescending(m => m.Value).Take(PTMagicConfiguration.GeneralSettings.Monitor.MaxTopMarkets);
@@ -81,14 +74,7 @@ namespace Monitor.Pages
           }
           double profit = 0;
           int trades = PTData.SellLog.FindAll(t => t.SoldDate.Date == salesDate.Date).Count;
-          if (PTData.Properties.Shorting)
-          {
-            profit = PTData.SellLog.FindAll(t => t.SoldDate.Date == salesDate.Date).Sum(t => t.Profit * (-1));
-          }
-          else
-          {
-            profit = PTData.SellLog.FindAll(t => t.SoldDate.Date == salesDate.Date).Sum(t => t.Profit);
-          }
+          profit = PTData.SellLog.FindAll(t => t.SoldDate.Date == salesDate.Date).Sum(t => t.Profit);
           double profitFiat = Math.Round(profit * Summary.MainMarketPrice, 2);
           balance += profitFiat; 
           tradesPerDayJSON += "{x: new Date('" + salesDate.Date.ToString("yyyy-MM-dd") + "'), y: " + trades + "}";
@@ -124,14 +110,7 @@ namespace Monitor.Pages
         {
           List<SellLogData> salesDateSales = PTData.SellLog.FindAll(sl => sl.SoldDate.Date == salesDate);
           double salesDateProfit;
-          if (PTData.Properties.Shorting)
-          {
-            salesDateProfit = salesDateSales.Sum(sl => sl.Profit * (-1));
-          }
-          else 
-          {
-            salesDateProfit = salesDateSales.Sum(sl => sl.Profit);
-          }
+          salesDateProfit = salesDateSales.Sum(sl => sl.Profit);
           double salesDateStartBalance = PTData.GetSnapshotBalance(salesDate);
           double salesDateGain = Math.Round(salesDateProfit / salesDateStartBalance * 100, 2);
           DailyGains.Add(salesDate, salesDateGain);
@@ -142,14 +121,7 @@ namespace Monitor.Pages
         {
           List<Core.Main.DataObjects.PTMagicData.SellLogData> salesMonthSales = PTData.SellLog.FindAll(sl => sl.SoldDate.Date.Month == salesMonthDate.Month && sl.SoldDate.Date.Year == salesMonthDate.Year);
           double salesDateProfit;
-          if (PTData.Properties.Shorting)
-          {
-            salesDateProfit = salesMonthSales.Sum(sl => sl.Profit * (-1));
-          }
-          else
-          {
-            salesDateProfit = salesMonthSales.Sum(sl => sl.Profit);
-          }
+          salesDateProfit = salesMonthSales.Sum(sl => sl.Profit);
           double salesDateStartBalance = PTData.GetSnapshotBalance(salesMonthDate);
           double salesDateGain = Math.Round(salesDateProfit / salesDateStartBalance * 100, 2);
           MonthlyGains.Add(salesMonthDate, salesDateGain);

--- a/Monitor/Pages/_get/DashboardBottom.cshtml
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml
@@ -121,14 +121,7 @@
       @{
 
         double totalProfit = 0;
-        if (Model.PTData.Properties.Shorting)
-        {
-          totalProfit = Model.PTData.SellLog.Sum(s => s.Profit * (-1));
-        }
-        else
-        {
-          totalProfit = Model.PTData.SellLog.Sum(s => s.Profit);
-        }
+        totalProfit = Model.PTData.SellLog.Sum(s => s.Profit);
         double totalProfitFiat = Math.Round(totalProfit * Model.Summary.MainMarketPrice, 2);
         double percentGain = Math.Round(totalProfit / Model.PTMagicConfiguration.GeneralSettings.Application.StartBalance * 100, 2);
         string percentGainText = percentGain.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) + "%";
@@ -138,53 +131,25 @@
         }
 
         double todaysProfit = 0;
-        if (Model.PTData.Properties.Shorting)
-        {
-          todaysProfit = Model.PTData.SellLogToday.Sum(s => s.Profit * (-1));
-        }
-        else
-        {
-          todaysProfit = Model.PTData.SellLogToday.Sum(s => s.Profit);
-        }
+        todaysProfit = Model.PTData.SellLogToday.Sum(s => s.Profit);
         double todaysStartBalance = Model.PTData.GetSnapshotBalance(Model.DateTimeNow.DateTime);
         double todaysProfitFiat = Math.Round(todaysProfit * Model.Summary.MainMarketPrice, 2);
         double todaysPercentGain = Math.Round(todaysProfit / todaysStartBalance * 100, 2);
 
         double yesterdaysProfit = 0;
-        if (Model.PTData.Properties.Shorting)
-        {
-          yesterdaysProfit = Model.PTData.SellLogYesterday.Sum(s => s.Profit * (-1));
-        }
-        else
-        {
-          yesterdaysProfit = Model.PTData.SellLogYesterday.Sum(s => s.Profit);
-        }
+        yesterdaysProfit = Model.PTData.SellLogYesterday.Sum(s => s.Profit);
         double yesterdaysStartBalance = Model.PTData.GetSnapshotBalance(Model.DateTimeNow.DateTime.AddDays(-1));
         double yesterdaysProfitFiat = Math.Round(yesterdaysProfit * Model.Summary.MainMarketPrice, 2);
         double yesterdaysPercentGain = Math.Round(yesterdaysProfit / yesterdaysStartBalance * 100, 2);
 
         double last7DaysProfit = 0;
-        if (Model.PTData.Properties.Shorting)
-        {
-          last7DaysProfit = Model.PTData.SellLogLast7Days.Sum(s => s.Profit * (-1));
-        }
-        else
-        {
-          last7DaysProfit = Model.PTData.SellLogLast7Days.Sum(s => s.Profit);
-        }
+        last7DaysProfit = Model.PTData.SellLogLast7Days.Sum(s => s.Profit);
         double last7DaysStartBalance = Model.PTData.GetSnapshotBalance(Model.DateTimeNow.DateTime.AddDays(-7));
         double last7DaysProfitFiat = Math.Round(last7DaysProfit * Model.Summary.MainMarketPrice, 2);
         double last7DaysPercentGain = Math.Round(last7DaysProfit / last7DaysStartBalance * 100, 2);
 
         double last30DaysProfit = 0;
-        if (Model.PTData.Properties.Shorting)
-        {
-          last30DaysProfit = Model.PTData.SellLogLast30Days.Sum(s => s.Profit * (-1));
-        }
-        else
-        {
-          last30DaysProfit = Model.PTData.SellLogLast30Days.Sum(s => s.Profit);
-        }
+        last30DaysProfit = Model.PTData.SellLogLast30Days.Sum(s => s.Profit);
         double last30DaysStartBalance = Model.PTData.GetSnapshotBalance(Model.DateTimeNow.DateTime.AddDays(-30));
         double last30DaysProfitFiat = Math.Round(last30DaysProfit * Model.Summary.MainMarketPrice, 2);
         double last30DaysPercentGain = Math.Round(last30DaysProfit / last30DaysStartBalance * 100, 2);

--- a/Monitor/Pages/_get/DashboardBottom.cshtml.cs
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml.cs
@@ -145,10 +145,6 @@ namespace Monitor.Pages
           }
           int trades = PTData.SellLog.FindAll(t => t.SoldDate.Date == salesDate).Count;
           double profit = PTData.SellLog.FindAll(t => t.SoldDate.Date == salesDate).Sum(t => t.Profit);
-          if (PTData.Properties.Shorting)
-          {
-            profit = profit * (-1);
-          }
           double profitFiat = Math.Round(profit * Summary.MainMarketPrice, 2);
           profitPerDayJSON += "{x: new Date('" + salesDate.ToString("yyyy-MM-dd") + "'), y: " + profitFiat.ToString("0.00", new System.Globalization.CultureInfo("en-US")) + "}";
           tradeDayIndex++;

--- a/Monitor/Pages/_get/TickerWidgets.cshtml
+++ b/Monitor/Pages/_get/TickerWidgets.cshtml
@@ -11,24 +11,29 @@
   }
 
   // Global setting tool tip
-  string globalSettingInfoIcon = "<i class=\"fa fa-info-circle text-muted\" data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\" title=\"<b>Instance: </b>" + Model.PTMagicConfiguration.GeneralSettings.Application.InstanceName + "\" data-template=\"<div class='tooltip' role='tooltip'><div class='tooltip-arrow'></div><div class='tooltip-inner tooltip-100 text-left'></div></div>\"></i>";
+   string globalIconColor = "text-success";
+   string globalSettingInfoIcon = "<i class=\"fa fa-info-circle text-muted\" data-toggle=\"tooltip\" data-placement=\"top\" data-html=\"true\" title=\"<b>Instance: </b>" + Model.PTMagicConfiguration.GeneralSettings.Application.InstanceName + "\" data-template=\"<div class='tooltip' role='tooltip'><div class='tooltip-arrow'></div><div class='tooltip-inner tooltip-100 text-left'></div></div>\"></i>";
+  if (Model.PTData.Properties.Shorting)
+  {
+    globalIconColor = "text-danger";
+  }
 
   // Health indicator
   DateTime lastRuntime = Model.Summary.LastRuntime;
   double elapsedSecondsSinceRuntime = DateTime.UtcNow.Subtract(lastRuntime).TotalSeconds;
   double intervalSeconds = Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes * 60.0;
 
-  string iconColor = "text-success";
+  string healthIconColor = "text-success";
   string ptMagicHealthIcon = "fa-heartbeat";
   string ptMagicHealthTooltip = "PT Magic is alive and healthy! Time elapsed since last run:  " + Math.Round(elapsedSecondsSinceRuntime / 60, 1) + " mins.";
   if (elapsedSecondsSinceRuntime > (intervalSeconds * 2)) {
     ptMagicHealthIcon = "fa-exclamation-triangle";
     ptMagicHealthTooltip = "PT Magic seems to have problems, check the logs!  Time elapsed since last run:  " + Math.Round(elapsedSecondsSinceRuntime / 60, 1) + " mins.";
-    iconColor = "text-danger";
+    healthIconColor = "text-danger";
   }
 }
 
-<div class="card-box card-box-mini card-box-ptmagic-outlined">
+<div class="card-box card-box-mini card-box-ptmagic-outlined @globalIconColor">
    <span data-toggle="tooltip" data-placement="bottom" title="Active global setting">
    @Core.Helper.SystemHelper.SplitCamelCase(Model.Summary.CurrentGlobalSetting.SettingName)</span><span class = "header-title"><a href="StatusSummary">@Html.Raw(" " + globalSettingInfoIcon)</a></span>
 </div>
@@ -37,8 +42,8 @@
   <span data-toggle="tooltip" data-placement="bottom" title="Active single market settings"><b>SMS: </b></span><span class = "header-title"><a href="ManageSMS">@Html.Raw(activeSingleSettings + " " + singleSettingInfoIcon)</a></span>
 </div>
 
-<div class="card-box card-box-mini card-box-ptmagic-status-outlined @iconColor" data-toggle="tooltip" data-placement="bottom" title="@ptMagicHealthTooltip">
-  <i class="fa @ptMagicHealthIcon @iconColor"></i>
+<div class="card-box card-box-mini card-box-ptmagic-status-outlined @healthIconColor" data-toggle="tooltip" data-placement="bottom" title="@ptMagicHealthTooltip">
+  <i class="fa @ptMagicHealthIcon @healthIconColor"></i>
 </div>
 
 <script type="text/javascript">

--- a/Monitor/Pages/_get/TickerWidgets.cshtml.cs
+++ b/Monitor/Pages/_get/TickerWidgets.cshtml.cs
@@ -20,6 +20,7 @@ namespace Monitor.Pages {
     }
 
     private void BindData() {
+      PTData = this.PtDataObject;
       // Get markets with active single settings
       var MarketsWithSingleSettingsData = from x in Summary.MarketSummary
                                           where x.Value.ActiveSingleSettings != null


### PR DESCRIPTION
- Fixed an issue when calculating profits while shorting.  Old code to calculate profit for individual sales and invert totals was removed, since PT's API now provides all necessary data.