### PR TITLE
Change IntervalMinutes to IntervalSeconds for the MarketAnalyzer settings

### DIFF
--- a/Core/DataObjects/PTMagicData.cs
+++ b/Core/DataObjects/PTMagicData.cs
@@ -118,7 +118,7 @@ namespace Core.Main.DataObjects.PTMagicData
   public class MarketAnalyzer
   {
     public int StoreDataMaxHours { get; set; }
-    public int IntervalMinutes { get; set; } = 5;
+    public int IntervalSeconds { get; set; } = 300;
     public bool ExcludeMainCurrency { get; set; } = true;
     public List<MarketTrend> MarketTrends { get; set; }
   }

--- a/Core/Main/PTMagic.cs
+++ b/Core/Main/PTMagic.cs
@@ -822,11 +822,11 @@ namespace Core.Main
 
     public void StartPTMagicIntervalTimer()
     {
-      this.Timer = new System.Timers.Timer(this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes * 60 * 1000);
+      this.Timer = new System.Timers.Timer(this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds * 1000);
       this.Timer.Enabled = true;
       this.Timer.Elapsed += new System.Timers.ElapsedEventHandler(this.PTMagicIntervalTimer_Elapsed);
 
-      this.Log.DoLogInfo("Checking market trends every " + this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes.ToString() + " minutes...");
+      this.Log.DoLogInfo("Checking market trends every " + this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds.ToString() + " seconds...");
 
       // Fire the first start immediately
       this.PTMagicIntervalTimer_Elapsed(null, null);
@@ -959,7 +959,7 @@ namespace Core.Main
               {
                 this.Log.DoLogInfo("+   " + activeSMS + ": " + this.SingleMarketSettingsCount[activeSMS].ToString());
               }
-              this.Log.DoLogInfo("+ " + this.TotalElapsedSeconds.ToString() + " Magicbots killed in " + this.RunCount.ToString() + " raids on Cryptodragon's Lair " + this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes.ToString() + ".");
+              this.Log.DoLogInfo("+ " + this.TotalElapsedSeconds.ToString() + " Magicbots killed in " + this.RunCount.ToString() + " raids on Cryptodragon's Lair, next refresh in " + this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds.ToString() + " seconds.");
               this.Log.DoLogInfo("");
               this.Log.DoLogInfo("DO NOT CLOSE THIS WINDOW! THIS IS THE BOT THAT ANALYZES TRENDS AND CHANGES SETTINGS!");
               this.Log.DoLogInfo("");
@@ -997,9 +997,9 @@ namespace Core.Main
           if (File.Exists(Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + Constants.PTMagicPathData + Path.DirectorySeparatorChar + "LastRuntimeSummary.json"))
           {
             FileInfo fiLastSummary = new FileInfo(Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + Constants.PTMagicPathData + Path.DirectorySeparatorChar + "LastRuntimeSummary.json");
-            if (fiLastSummary.LastWriteTimeUtc < DateTime.UtcNow.AddMinutes(-(this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes * 2)))
+            if (fiLastSummary.LastWriteTimeUtc < DateTime.UtcNow.AddSeconds(-(this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds * 2)))
             {
-              Log.DoLogWarn("PTMagic raid " + this.RunCount.ToString() + " is taking longer than expected.  Consider increasing your IntervalMinues setting, reducing other processes on your PC, or raising PTMagic's priority.");
+              Log.DoLogWarn("PTMagic raid " + this.RunCount.ToString() + " is taking longer than expected.  Consider increasing your IntervalSeconds setting, reducing other processes on your PC, or raising PTMagic's priority.");
               this.State = Constants.PTMagicBotState_Idle;
               Log.DoLogInfo("PTMagic status reset, waiting for the next raid to be good to go again.");
             }
@@ -1054,13 +1054,13 @@ namespace Core.Main
           this.LastSettingFileCheck = DateTime.UtcNow;
           result = true;
 
-          if (this.Timer.Interval != this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes * 60 * 1000)
+          if (this.Timer.Interval != this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds * 1000)
           {
-            Log.DoLogInfo("Setting for 'IntervalMinutes' changed in MarketAnalyzer, setting new timer...");
+            Log.DoLogInfo("Setting for 'IntervalSeconds' changed in MarketAnalyzer, setting new timer...");
             this.Timer.Stop();
-            this.Timer.Interval = this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes * 60 * 1000;
+            this.Timer.Interval = this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds * 1000;
             this.Timer.Start();
-            Log.DoLogInfo("New timer set to " + this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes.ToString() + " minutes.");
+            Log.DoLogInfo("New timer set to " + this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds.ToString() + " seconds.");
           }
 
           SettingsFiles.CheckPresets(this.PTMagicConfiguration, this.Log, true);
@@ -1269,7 +1269,7 @@ namespace Core.Main
       // Check if problems occured during the Exchange contact
       if (this.ExchangeMarketList == null)
       {
-        Exception ex = new Exception("Unable to contact " + this.PTMagicConfiguration.GeneralSettings.Application.Exchange + " for fresh market data. Trying again in " + this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes + " minute(s).");
+        Exception ex = new Exception("Unable to contact " + this.PTMagicConfiguration.GeneralSettings.Application.Exchange + " for fresh market data. Trying again in " + this.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds + " second(s).");
         Log.DoLogError(ex.Message);
         this.State = Constants.PTMagicBotState_Idle;
         throw ex;

--- a/Core/MarketAnalyzer/CoinMarketCap.cs
+++ b/Core/MarketAnalyzer/CoinMarketCap.cs
@@ -94,7 +94,7 @@ namespace Core.MarketAnalyzer
       if (marketFiles.Count > 0)
       {
         marketFile = marketFiles.First();
-        if (marketFile.LastWriteTimeUtc <= DateTime.UtcNow.AddHours(-24).AddMinutes(-systemConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes).AddSeconds(-10))
+        if (marketFile.LastWriteTimeUtc <= DateTime.UtcNow.AddHours(-24).AddSeconds(-systemConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds).AddSeconds(-10))
         {
           log.DoLogDebug("CoinMarketCap - 24h market data file too old (" + marketFile.LastWriteTimeUtc.ToString() + "). Rebuilding data...");
           build24hMarketDataFile = true;
@@ -110,7 +110,7 @@ namespace Core.MarketAnalyzer
         if (marketFiles.Count > 0)
         {
           marketFile = marketFiles.First();
-          if (marketFile.LastWriteTimeUtc >= DateTime.UtcNow.AddHours(-24).AddMinutes(systemConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes).AddSeconds(10))
+          if (marketFile.LastWriteTimeUtc >= DateTime.UtcNow.AddHours(-24).AddSeconds(systemConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds).AddSeconds(10))
           {
             log.DoLogDebug("CoinMarketCap - 24h market data file too young (" + marketFile.LastWriteTimeUtc.ToString() + "). Rebuilding data...");
             build24hMarketDataFile = true;

--- a/Core/MarketAnalyzer/Poloniex.cs
+++ b/Core/MarketAnalyzer/Poloniex.cs
@@ -237,7 +237,7 @@ namespace Core.MarketAnalyzer
         latestMarketDataFileDateTime = latestMarketDataFile.LastWriteTimeUtc;
       }
 
-      if (latestMarketDataFileDateTime < DateTime.UtcNow.AddMinutes(-(systemConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes * 3)))
+      if (latestMarketDataFileDateTime < DateTime.UtcNow.AddSeconds(-(systemConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds * 3)))
       {
         int lastMarketDataAgeInSeconds = (int)Math.Ceiling(DateTime.UtcNow.Subtract(latestMarketDataFileDateTime).TotalSeconds);
 

--- a/Core/ProfitTrailer/SettingsFiles.cs
+++ b/Core/ProfitTrailer/SettingsFiles.cs
@@ -96,7 +96,7 @@ namespace Core.ProfitTrailer
           if (presetFilePath.IndexOf(".properties", StringComparison.InvariantCultureIgnoreCase) > -1)
           {
             FileInfo presetFile = new FileInfo(presetFilePath);
-            if (presetFile.LastWriteTimeUtc > DateTime.UtcNow.AddMinutes(-systemConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes).AddSeconds(2))
+            if (presetFile.LastWriteTimeUtc > DateTime.UtcNow.AddSeconds(-systemConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds).AddSeconds(2))
             {
 
               // File has changed recently, force preparation check

--- a/Monitor/Pages/SettingsAnalyzer.cshtml
+++ b/Monitor/Pages/SettingsAnalyzer.cshtml
@@ -122,9 +122,9 @@
         </div>
 
         <div class="form-group row">
-          <label class="col-md-4 col-form-label">Interval Minutes <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Interval in minutes for PTMagic to check market trends and triggers."></i></label>
+          <label class="col-md-4 col-form-label">Interval Seconds <i class="fa fa-info-circle text-muted" data-toggle="tooltip" data-placement="top" title="Interval in minutes for PTMagic to check market trends and triggers."></i></label>
           <div class="col-md-8">
-            <input type="text" class="form-control" name="MarketAnalyzer_IntervalMinutes" value="@Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes.ToString()">
+            <input type="text" class="form-control" name="MarketAnalyzer_IntervalSeconds" value="@Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds.ToString()">
           </div>
         </div>
 

--- a/Monitor/Pages/SettingsAnalyzer.cshtml.cs
+++ b/Monitor/Pages/SettingsAnalyzer.cshtml.cs
@@ -33,7 +33,7 @@ namespace Monitor.Pages
       base.Init();
 
       PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours = SystemHelper.TextToInteger(HttpContext.Request.Form["MarketAnalyzer_StoreDataMaxHours"], PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours);
-      PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes = SystemHelper.TextToInteger(HttpContext.Request.Form["MarketAnalyzer_IntervalMinutes"], PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes);
+      PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds = SystemHelper.TextToInteger(HttpContext.Request.Form["MarketAnalyzer_IntervalSeconds"], PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds);
       PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.ExcludeMainCurrency = HttpContext.Request.Form["MarketAnalyzer_ExcludeMainCurrency"].Equals("on");
 
       List<string> formKeys = HttpContext.Request.Form.Keys.ToList();

--- a/Monitor/Pages/StatusSummary.cshtml
+++ b/Monitor/Pages/StatusSummary.cshtml
@@ -16,7 +16,7 @@
       @{
         DateTime lastRuntime = Model.Summary.LastRuntime;
         double elapsedSecondsSinceRuntime = DateTime.UtcNow.Subtract(lastRuntime).TotalSeconds;
-        double intervalSeconds = Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes * 60.0;
+        double intervalSeconds = Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds;
 
         string ptMagicHealthIcon = "<i class=\"fa fa-heartbeat text-success\" data-toggle=\"tooltip\" data-placement=\"top\" title=\"PT Magic is alive and healthy!\"></i>";
         if (elapsedSecondsSinceRuntime > (intervalSeconds + intervalSeconds)) {

--- a/Monitor/Pages/_get/TickerWidgets.cshtml
+++ b/Monitor/Pages/_get/TickerWidgets.cshtml
@@ -16,7 +16,7 @@
   // Health indicator
   DateTime lastRuntime = Model.Summary.LastRuntime;
   double elapsedSecondsSinceRuntime = DateTime.UtcNow.Subtract(lastRuntime).TotalSeconds;
-  double intervalSeconds = Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalMinutes * 60.0;
+  double intervalSeconds = Model.PTMagicConfiguration.AnalyzerSettings.MarketAnalyzer.IntervalSeconds;
 
   string iconColor = "text-success";
   string ptMagicHealthIcon = "fa-heartbeat";

--- a/PTMagic/_defaults/_default_settings_PT_2.x/settings.analyzer.json
+++ b/PTMagic/_defaults/_default_settings_PT_2.x/settings.analyzer.json
@@ -12,7 +12,7 @@
   "AnalyzerSettings": {
     "MarketAnalyzer": {
       "StoreDataMaxHours": 48,		// Number of hours to store market data
-      "IntervalMinutes": 2,			// Interval in minutes for PTMagic to check market trends and triggers
+      "IntervalSeconds": 120,			// Interval in seconds for PTMagic to check market trends and triggers
       "ExcludeMainCurrency": true,	// Excludes the main currency (for example BTC) from market trend analysis
       "MarketTrends": [
         {

--- a/_Development/DevSettings/settings.analyzer.json
+++ b/_Development/DevSettings/settings.analyzer.json
@@ -12,7 +12,7 @@
   "AnalyzerSettings": {
     "MarketAnalyzer": {
       "StoreDataMaxHours": 48,		// Number of hours to store market data
-      "IntervalMinutes": 2,			// Interval in minutes for PTMagic to check market trends and triggers
+      "IntervalSeconds": 120,			// Interval in seconds for PTMagic to check market trends and triggers
       "ExcludeMainCurrency": true,	// Excludes the main currency (for example BTC) from market trend analysis
       "MarketTrends": [
         {


### PR DESCRIPTION
Changes the setting IntervalMinutes to IntervalSeconds for the MarketAnalyzer settings allowing finer tuning of refreshes.