### PR TITLE
remove pending orders

### DIFF
--- a/Core/DataObjects/ProfitTrailerData.cs
+++ b/Core/DataObjects/ProfitTrailerData.cs
@@ -384,7 +384,7 @@ namespace Core.Main.DataObjects
       _dcaLog.AddRange(ParsePairsData(rawPairsLogData, false));
 
       // Parse pending pairs data
-      _dcaLog.AddRange(ParsePairsData(rawPendingLogData, false));
+      //_dcaLog.AddRange(ParsePairsData(rawPendingLogData, false));
 
       // Parse watch only pairs data
       _dcaLog.AddRange(ParsePairsData(rawWatchModeLogData, false));


### PR DESCRIPTION
Unknown  changes to PT's API data regarding pending orders causes an issue when rendering dashboard.top.

Temporarily fixed by removing pending orders completely, until further investigation and resolution.