### PR TITLE
Changes for 2.6.1

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0" />
     <PackageReference Include="SharpZipLib" Version="*" />
     <PackageReference Include="Telegram.Bot" Version="*" />
   </ItemGroup>

--- a/Core/MarketAnalyzer/Binance.cs
+++ b/Core/MarketAnalyzer/Binance.cs
@@ -360,12 +360,12 @@ namespace Core.MarketAnalyzer
         log.DoLogDebug("Binance - Getting ticks for '" + markets.Count + "' markets");
         ConcurrentDictionary<string, List<MarketTick>> marketTicks = new ConcurrentDictionary<string, List<MarketTick>>();
 
-        int ParallelThrottle = 4;
-        if (systemConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours > 50)
+        int ParallelThrottle = 2;
+        if (systemConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours > 6)
         {
-          ParallelThrottle = 2;
+          ParallelThrottle = 1;
           log.DoLogInfo("----------------------------------------------------------------------------");
-          log.DoLogInfo("StoreDataMaxHours is greater than 50.  Historical data requests will be");
+          log.DoLogInfo("StoreDataMaxHours is greater than 6.  Historical data requests will be");
           log.DoLogInfo("throttled to avoid exceeding exchange request limits.  This initial ");
           log.DoLogInfo("run could take more than 30 minutes.  Please go outside for a walk...");
           log.DoLogInfo("----------------------------------------------------------------------------");

--- a/Core/MarketAnalyzer/BinanceFutures.cs
+++ b/Core/MarketAnalyzer/BinanceFutures.cs
@@ -71,7 +71,7 @@ namespace Core.MarketAnalyzer
               //New variables for filtering out bad markets
               float marketLastPrice = currencyTicker["lastPrice"].ToObject<float>();
               float marketVolume = currencyTicker["volume"].ToObject<float>();
-              if (marketLastPrice > 0 && marketVolume > 0)
+              if (marketLastPrice > 0 && marketVolume > 0 && marketName.EndsWith(mainMarket))
                 {
 
                   // Set last values in case any error occurs
@@ -92,8 +92,15 @@ namespace Core.MarketAnalyzer
                 }
                 else
                 {
-                  //Let the user know that the problem market was ignored.
+                  //Let the user know that a problem market was ignored.
+                  if (!marketName.EndsWith(mainMarket))
+                  {
+                    log.DoLogInfo("BinanceFutures - Incorrect base currency: " + marketName + " ignored");
+                  }
+                  else
+                  {
                   log.DoLogInfo("BinanceFutures - Ignoring bad market data for " + marketName);
+                  }
                 }
             }
 

--- a/Core/MarketAnalyzer/BinanceFutures.cs
+++ b/Core/MarketAnalyzer/BinanceFutures.cs
@@ -357,12 +357,12 @@ namespace Core.MarketAnalyzer
         log.DoLogDebug("BinanceFutures - Getting ticks for '" + markets.Count + "' markets");
         ConcurrentDictionary<string, List<MarketTick>> marketTicks = new ConcurrentDictionary<string, List<MarketTick>>();
 
-        int ParallelThrottle = 4;
-        if (systemConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours > 50)
+        int ParallelThrottle = 2;
+        if (systemConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours > 6)
         {
-          ParallelThrottle = 2;
+          ParallelThrottle = 1;
           log.DoLogInfo("----------------------------------------------------------------------------");
-          log.DoLogInfo("StoreDataMaxHours is greater than 50.  Historical data requests will be");
+          log.DoLogInfo("StoreDataMaxHours is greater than 6.  Historical data requests will be");
           log.DoLogInfo("throttled to avoid exceeding exchange data request limits.  This initial ");
           log.DoLogInfo("run could take more than 30 minutes.  Please go outside for a walk...");
           log.DoLogInfo("----------------------------------------------------------------------------");

--- a/Core/MarketAnalyzer/BinanceUS.cs
+++ b/Core/MarketAnalyzer/BinanceUS.cs
@@ -370,12 +370,12 @@ namespace Core.MarketAnalyzer
         log.DoLogDebug("BinanceUS - Getting ticks for '" + markets.Count + "' markets");
         ConcurrentDictionary<string, List<MarketTick>> marketTicks = new ConcurrentDictionary<string, List<MarketTick>>();
 
-        int ParallelThrottle = 4;
-        if (systemConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours > 200)
+        int ParallelThrottle = 2;
+        if (systemConfiguration.AnalyzerSettings.MarketAnalyzer.StoreDataMaxHours > 6)
         {
-          ParallelThrottle = 2;
+          ParallelThrottle = 1;
           log.DoLogInfo("----------------------------------------------------------------------------");
-          log.DoLogInfo("StoreDataMaxHours is greater than 200.  Historical data requests will be");
+          log.DoLogInfo("StoreDataMaxHours is greater than 6.  Historical data requests will be");
           log.DoLogInfo("throttled to avoid exceeding exchange data request limits.  This initial ");
           log.DoLogInfo("run could take more than 30 minutes.  Please go outside for a walk...");
           log.DoLogInfo("----------------------------------------------------------------------------");

--- a/Monitor/Monitor.csproj
+++ b/Monitor/Monitor.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp7.0</TargetFramework>
     <!--<PublishWithAspNetCoreTargetManifest>false</PublishWithAspNetCoreTargetManifest>-->
   </PropertyGroup>
   <ItemGroup>
@@ -19,7 +19,7 @@
     <None Include="nlog.config" CopyToOutputDirectory="Always" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Monitor/Pages/MarketAnalyzer.cshtml
+++ b/Monitor/Pages/MarketAnalyzer.cshtml
@@ -250,6 +250,8 @@ else
         </thead>
         <tbody>
           @foreach (string market in Model.Summary.MarketSummary.Keys.OrderBy(m => m)) {
+            if (market.EndsWith(Model.Summary.MainMarket))
+            {
             Core.Main.DataObjects.PTMagicData.MarketPairSummary mps = Model.Summary.MarketSummary[market];
             int marketTrendsDisplayed = 0;
             <tr>
@@ -294,6 +296,7 @@ else
                 <td></td>
               }
             </tr>
+            }
           }
         </tbody>
       </table>

--- a/Monitor/Pages/_get/DashboardTop.cshtml
+++ b/Monitor/Pages/_get/DashboardTop.cshtml
@@ -111,6 +111,7 @@
               @foreach (Core.Main.DataObjects.PTMagicData.DCALogData dcaLogEntry in Model.PTData.DCALog.OrderByDescending(d => d.ProfitPercent).Take(Model.PTMagicConfiguration.GeneralSettings.Monitor.MaxDashboardBagEntries)) {
                 // Loop through the pairs preparing the data for display
                 Core.Main.DataObjects.PTMagicData.MarketPairSummary mps = null;
+
                 if (Model.Summary.MarketSummary.ContainsKey(dcaLogEntry.Market)) {
                   mps = Model.Summary.MarketSummary[dcaLogEntry.Market];
                 }
@@ -149,22 +150,26 @@
                 
                 // Check for when PT loses the value of a pair
                 bool lostValue = false;
-                lostValue = (dcaLogEntry.TotalCost == 0.0) || (dcaLogEntry.AverageBuyPrice == 0.0);
+                lostValue = !(sellStrategyText.Contains("WATCHMODE")) && !(sellStrategyText.Contains("PENDING")) && ((dcaLogEntry.TotalCost == 0.0) || (dcaLogEntry.AverageBuyPrice == 0.0));
 
                 // Profit percentage
                 var profitPercentage = dcaLogEntry.ProfitPercent;
                      
-                if (dcaLogEntry.SellStrategies != null)
-                {
-                  var gainStrategy = dcaLogEntry.SellStrategies.FirstOrDefault(x => x.Name.Contains(" GAIN", StringComparison.InvariantCultureIgnoreCase));
-                  if (gainStrategy != null)
-                  {
-                    // Use the gain percentage value as it is accurate to what can be achieved with the order book!
-                    profitPercentage = gainStrategy.CurrentValue;
-                  }
-                }
+                // if (dcaLogEntry.SellStrategies != null)
+                // {
+                //   var gainStrategy = dcaLogEntry.SellStrategies.FirstOrDefault(x => x.Name.Contains(" GAIN", StringComparison.InvariantCultureIgnoreCase));
+                //   if (gainStrategy != null)
+                //   {
+                //     // Use the gain percentage value as it is accurate to what can be achieved with the order book!
+                //     profitPercentage = gainStrategy.CurrentValue;
+                //   }
+                // }
                 
                 // Render the row
+
+                 if (!sellStrategyText.Contains("PENDING-BUY"))
+                {
+
                 <tr @(lostValue ? "class=errorRow" : "") >
 
                   <!-- Market -->
@@ -207,8 +212,8 @@
                   <!-- Target/Profit -->
                   @if (!@lostValue)
                   {
-                    @if (!sellStrategyText.Contains("WATCHMODE"))
-                    {
+                    //@if (!sellStrategyText.Contains("WATCHMODE"))
+                    //{
                       @if (sellStrategyText.Contains("CROSSED"))
                       // if leverage, recalculate profit target
                       {
@@ -222,17 +227,31 @@
                         leverage = leverageText.Remove(leverageText.IndexOf(".0)"), leverageText.Length - leverageText.IndexOf(".0)"));
                         leverageValue = double.Parse(leverage);
                       }
-                      profitPercentage = profitPercentage * leverageValue; 
-                      double TargetGain = leverageValue * dcaLogEntry.TargetGainValue.Value;
-                      <td>@TargetGain.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"))%
-                        <br>
-                        <div class="text-autocolor">@profitPercentage.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"))%</div>
-                      </td>
-                    }
+                      //profitPercentage = profitPercentage * leverageValue;
+
+                      @if ( !(sellStrategyText.Contains("WATCHMODE")) && !(sellStrategyText.Contains("PENDING")))
+                      {
+                        double TargetGain = leverageValue * dcaLogEntry.TargetGainValue.Value;
+                        <td>@TargetGain.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"))%
+                          <br>
+                          <div class="text-autocolor">@profitPercentage.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"))%</div>
+                        </td>
+                      }
+                      else
+                      {
+                        <td>
+                          <div class="text-left">None</div>
+                          <br>
+                          <div class="text-autocolor">@profitPercentage.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"))%</div>
+                        </td>
+                      }
+
+                     
+                    //}
                   } 
                   else
                   {
-                    <td class="text-left">No Value!</td>
+                    <td class="text-left">Lost Value!</td>
                   }
                   <!-- Bag details -->
                   <td class="text-right"><a href="@Html.Raw(Model.PTMagicConfiguration.GeneralSettings.Monitor.RootUrl)_get/BagDetails/?m=@dcaLogEntry.Market" data-remote="false" data-toggle="modal" data-target="#dca-chart"><i class="fa fa-plus-circle"></i></a></td>
@@ -243,6 +262,9 @@
                   Model.TotalBagCost = Model.TotalBagCost + dcaLogEntry.TotalCost;
                   Model.TotalBagGain =  Model.TotalBagGain + bagGain;
                 }
+
+                } 
+
               }
             <td>Totals:</td>
             <td></td>

--- a/Monitor/Program.cs
+++ b/Monitor/Program.cs
@@ -10,7 +10,7 @@ namespace Monitor
   public class Program
   {
     // Main entry point
-    [SecurityPermission(SecurityAction.Demand, Flags = SecurityPermissionFlag.ControlAppDomain)]
+    //[SecurityPermission(SecurityAction.Demand, Flags = SecurityPermissionFlag.ControlAppDomain)]
     public static void Main(string[] args)
     {
       // Register a global exception handler

--- a/PTMagic/PTMagic.csproj
+++ b/PTMagic/PTMagic.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp7.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/PTMagic/Program.cs
+++ b/PTMagic/Program.cs
@@ -6,7 +6,7 @@ using Core.Helper;
 using Microsoft.Extensions.DependencyInjection;
 
 
-[assembly: AssemblyVersion("2.5.12")]
+[assembly: AssemblyVersion("2.6.1")]
 [assembly: AssemblyProduct("PT Magic")]
 
 namespace PTMagic


### PR DESCRIPTION
- PTMagic  requires ASP.Net Core Runtime 7.x on the host operating system (download: https://dotnet.microsoft.com/en-us/download/dotnet/7.0)

# > Changes 
- Setting "Max Dashboard Buy Entries" to zero, via the gui or editing the settings, will hide the possible buy list in the PTMagic dashboard.  It has no effect on your actual possible buy list in Profit Trailer.

- Increased throttling for the initial collection of market data beyond six hours to avoid IP bans from Binance

- Fixed an issue causing Pending orders to break DashboardTop

- Fixed an issue where coins in Watchmod or Pending were not displaying their current profit value

- Made a change to prevent Pending Buy orders from showing up in the Pairs/DCA/Pending list on DashboardTop

- Any coin pairs, including quarterly futures, that do not end with the base market specified by Profit trailer (eg., USDT) will be completely ignored by PTMagic. This fixes an issue with Binance futures that allowed data for pairs from other markets to be collected and used to create trends (eg., data for BTCBUSD and BTCUSDT were both being collected, analyzed, and written to Profit Trailer's settings). 