### PR TITLE
Monitor TargetGain Error

### DIFF
--- a/Core/DataObjects/PTMagicData.cs
+++ b/Core/DataObjects/PTMagicData.cs
@@ -519,7 +519,7 @@ namespace Core.Main.DataObjects.PTMagicData
     public double AverageBuyPrice { get; set; }
     public double TotalCost { get; set; }
     public double CurrentValue { get; set; }
-    public double TargetGainValue { get; set; }
+    public double? TargetGainValue { get; set; }
     public double Amount { get; set; }
     public double CurrentPrice { get; set; }
     public double SellTrigger { get; set; }

--- a/Core/DataObjects/PTMagicData.cs
+++ b/Core/DataObjects/PTMagicData.cs
@@ -519,7 +519,7 @@ namespace Core.Main.DataObjects.PTMagicData
     public double AverageBuyPrice { get; set; }
     public double TotalCost { get; set; }
     public double CurrentValue { get; set; }
-    public double? TargetGainValue { get; set; }
+    public double TargetGainValue { get; set; }
     public double Amount { get; set; }
     public double CurrentPrice { get; set; }
     public double SellTrigger { get; set; }

--- a/Monitor/Pages/_get/DashboardBottom.cshtml
+++ b/Monitor/Pages/_get/DashboardBottom.cshtml
@@ -38,7 +38,7 @@
     
   <div class="col-md-9">
     <div class="card-box px-2" style="height:240px;">
-      <h4 class="m-t-0 header-title"><b>Live TCV Trend </b><i class="fa fa-info-circle text-muted"  style="font-size x-small" data-toggle="tooltip" data-placement="top" title="Data is added while the monitor is running. Currently set to show the past @Model.PTMagicConfiguration.GeneralSettings.Monitor.LiveTCVTimeframeMinutes minutes in your monitor settings."></i>
+      <h4 class="m-t-0 header-title"><b>TCV Trend </b><i class="fa fa-info-circle text-muted"  style="font-size x-small" data-toggle="tooltip" data-placement="top" title="Data is added while the monitor is running. Currently set to show the past @Model.PTMagicConfiguration.GeneralSettings.Monitor.LiveTCVTimeframeMinutes minutes in your monitor settings."></i>
       @if (!Model.TotalCurrentValueLiveChartDataJSON.Equals("")) {
         <div class="TCVLive-chart">
           <svg style="height:220px;width:100%"></svg>

--- a/Monitor/Pages/_get/DashboardTop.cshtml
+++ b/Monitor/Pages/_get/DashboardTop.cshtml
@@ -221,7 +221,7 @@
 
                       @if ( !(sellStrategyText.Contains("WATCHMODE")) && !(sellStrategyText.Contains("PENDING")))
                       {
-                        double TargetGain = leverageValue * dcaLogEntry.TargetGainValue.Value;
+                        double TargetGain = leverageValue * dcaLogEntry.TargetGainValue.GetValueOrDefault();
                         <td>@TargetGain.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US"))%
                           <br>
                           <div class="text-autocolor" style="font-size: 1.2em; white-space: nowrap;">@profitPercentage.ToString("#,#0.00", new System.Globalization.CultureInfo("en-US")) %</div>


### PR DESCRIPTION
viva07 found an error in DashboardTop: If GAIN isn't used as a sell strategy, the value for the variable TargetGain isn't set correctly and creates a null value error.

also removed the word "LIVE" from the TCV trend chart.  Redundant.