### PR TITLE
2.8.5 - empty months

### DIFF
--- a/Core/DataObjects/ProfitTrailerData.cs
+++ b/Core/DataObjects/ProfitTrailerData.cs
@@ -567,7 +567,10 @@ namespace Core.Main.DataObjects
                                 if (extraSection != null)
                                 {
                                     JArray monthlyStatsSection = (JArray)extraSection["monthlyStats"];
-                                    _monthlyStats = monthlyStatsSection.Select(j => BuildMonthlyStatsData(j as JObject)).ToList();
+                                    _monthlyStats = monthlyStatsSection
+                                        .Where(j => j["totalSales"] != null && (double)j["totalSales"] != 0 && j["avgGrowth"] != null)
+                                        .Select(j => BuildMonthlyStatsData(j as JObject))
+                                        .ToList();
                                     _monthlyStatsRefresh = DateTime.UtcNow.AddSeconds(_systemConfiguration.GeneralSettings.Monitor.DashboardChartsRefreshSeconds - 1);
                                 }
                             }

--- a/PTMagic/Program.cs
+++ b/PTMagic/Program.cs
@@ -6,7 +6,7 @@ using Core.Helper;
 using Microsoft.Extensions.DependencyInjection;
 
 
-[assembly: AssemblyVersion("2.8.4")]
+[assembly: AssemblyVersion("2.8.5")]
 [assembly: AssemblyProduct("PT Magic")]
 
 namespace PTMagic


### PR DESCRIPTION
Fixes an issue when building monthly sales data for the monitor.

If a month had zero sales, the field AvgGrowth didn't exist in PT's sell record, causing a null object exception.